### PR TITLE
Add config section to controller docs

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -52,6 +52,30 @@ will create the directory, **api/controllers/comment/** with three files
 
 -->
 
+
+## Controller Configuration
+
+Controllers are configured globally in `config/blueprints.js`. You can override any global
+controller configuration options by adding a `_config` key to your controller configuration.
+
+For example, if you wanted to disable REST blueprints on a controller, your controller might look
+like this:
+
+```javascript
+// api/controllers/SampleController.js
+module.exports = {
+  _config: {
+    rest: false
+  },
+
+  index: function(req, res) {
+    // ...
+  }
+};
+```
+
+For a list of configuration options, see [controller configuration](config.controllers.md).
+
 ## How do I use the controller once I&rsquo;ve created it?
 After a controller has been defined, Sails will automatically map out routes to give you easy access.  
 For the controller above, the routes would be the following:  


### PR DESCRIPTION
Addresses https://github.com/balderdashy/sails/issues/1425.

I'm not totally sure if this is the optimal place for this--not totally positive if every file pertains to 0.10.x or if some are 0.9.x--so if there's another obvious place to put this and it's worthwhile, let me know and I'll move it.

I think every documentation file--especially those with an overridable config (e.g. models)--could benefit a similar configuration subheading. That's a change I could make across more files, what do you think?
