### PR TITLE
Added 'api' to sails generate

### DIFF
--- a/reference/CommandLine.md
+++ b/reference/CommandLine.md
@@ -52,7 +52,7 @@ This will create the file 'api/models/Pet.js'
 ######Generate both!
 
 ```sh
-catGuy@catGuy:~/nodeProjects/blogApp$ sails generate pet
+catGuy@catGuy:~/nodeProjects/blogApp$ sails generate api pet
 info: Generating model and controller for pet...
 ```
 


### PR DESCRIPTION
sails generate requires a generatorType (model|controller|api). The 'api' generatorType will create both the model and controller.
