### PR TITLE
Fixed the Controllers documentation to set 'shortcuts' in blueprints.js

### DIFF
--- a/controllers.md
+++ b/controllers.md
@@ -71,8 +71,8 @@ Additionally, thanks to blueprints, you also get these methods by default:
 `/:controller/update/:id`  
 `/:controller/destroy/:id`  
 
-To turn off the CRUD routes, simply set the &lsquo;shortcuts&rsquo; flag to false in `config/controllers.js`,  
-and to turn off REST routes, simply set the &lsquo;rest&rsquo; flag to false in `config/controllers.js`
+To turn off the CRUD routes, simply set the &lsquo;shortcuts&rsquo; flag to false in `config/blueprints.js`,  
+and to turn off REST routes, simply set the &lsquo;rest&rsquo; flag to false in `config/blueprints.js`
 
 ## The Request Object
 


### PR DESCRIPTION
0.10 does not have a controllers.js and uses blueprints.js for setting
the 'shortcuts'

Signed-off-by: Sateesh Kavuri sateesh.kavuri@gmail.com
