### PR TITLE
Update Models.md

### DIFF
--- a/reference/Models.md
+++ b/reference/Models.md
@@ -167,7 +167,7 @@ Specifies the type of data that will be stored in this attribute.  One of:
 
 - string
 - text
-- integer
+- int
 - float
 - date
 - time


### PR DESCRIPTION
If an attribute type is set to 'integer' as mentioned in this documentation, then search of records based on the attributes returns empty records. Changing the type to 'int' solves the problem and it is possible to search records using the integer attribute
