### PR TITLE
Info for (breaking) Waterline syntax change

### DIFF
--- a/reference/Upgrading.md
+++ b/reference/Upgrading.md
@@ -37,6 +37,11 @@ Finally, if you want to see all pubsub messages from all models, you can access 
 To see examples of the new pubsub methods in action, see [SailsChat](https://github.com/balderdashy/sailschat).
 
 
+##### Waterline Queries
+
+In Sails v0.9 the syntax for querying the database used to be `Model. [ … ] .done( fn )`. 
+In Sails v0.10 and Waterline v0.10 that changed to `Model. [ … ] .exec( fn )`.
+
 
 ##### Associations
 


### PR DESCRIPTION
Hi, I added a paragraph in order to note the syntax changes in Waterline queries. I just updated to Waterline 10-rc9 and got a lot of errors until I found out, that the all the final calls on Waterline queries had changed from the keyword .done() to .exec().

At least that's what I found and understood and my code works again, when I make this change, but maybe there's more to it? Would love to get some more info on this change – especially as it seems to be a breaking change.

All the best and thanks for the work you're putting into Sails!
Marcus
