### PR TITLE
updated concepts/Upgrading/Upgrading.md

### DIFF
--- a/concepts/Upgrading/Upgrading.md
+++ b/concepts/Upgrading/Upgrading.md
@@ -29,7 +29,7 @@ Thanks!
 |     | [Policies](#/documentation/concepts/Upgrading?q=policies) |
 |     | [Associations](#/documentation/concepts/Upgrading?q=associations) |
 |     | [Pubsub](#/documentation/concepts/Upgrading?q=pubsub) |
-|     | [`.done()` vs. `.exec()`](#/documentation/concepts/Upgrading?q=done()-vs-exec())
+|     | [`.done()` vs. `.exec()`](#/documentation/concepts/Upgrading?q=done&28%29-vs-exec&28%29)
 |     | [Generators](#/documentation/concepts/Upgrading?q=generators) |
 |     | [Command-Line Tool](#/documentation/concepts/Upgrading?q=commandline-tool) |
 |     | [Custom Server Responses](#/documentation/concepts/Upgrading?q=custom-server-responses) |


### PR DESCRIPTION
Fixed the 'done()-vs-exec()' link in the 'Contents' -> 'jump too...' section. Fixed by encoding the parentheses as '%28&29' instead of '()'. 

To make sure this fix works, I tested it out by compiling the new Markdown and verifying the `href=""` pointed to the correct link. Then I edited the http://sailsjs.org/#/documentation/concepts/Upgrading page with Firebug with the correct markdown created for the `href=""` part and then the link worked when I clicked it.
