### PR TITLE
properly fixed the link from PR #213

### DIFF
--- a/concepts/Upgrading/Upgrading.md
+++ b/concepts/Upgrading/Upgrading.md
@@ -29,7 +29,7 @@ Thanks!
 |     | [Policies](#/documentation/concepts/Upgrading?q=policies) |
 |     | [Associations](#/documentation/concepts/Upgrading?q=associations) |
 |     | [Pubsub](#/documentation/concepts/Upgrading?q=pubsub) |
-|     | [`.done()` vs. `.exec()`](#/documentation/concepts/Upgrading?q=done&28%29-vs-exec&28%29)
+|     | [`.done()` vs. `.exec()`](#/documentation/concepts/Upgrading?q=done%28%29-vs-exec%28%29)
 |     | [Generators](#/documentation/concepts/Upgrading?q=generators) |
 |     | [Command-Line Tool](#/documentation/concepts/Upgrading?q=commandline-tool) |
 |     | [Custom Server Responses](#/documentation/concepts/Upgrading?q=custom-server-responses) |


### PR DESCRIPTION
I used `&28` instead of `%28` when encoding `(` in the `href=""` link, this PR fixes what [PR #213](https://github.com/balderdashy/sails-docs/pull/213) was supposed to fix
