### PR TITLE
Update RouteTargetSyntax.md

### DIFF
--- a/concepts/Routes/RouteTargetSyntax.md
+++ b/concepts/Routes/RouteTargetSyntax.md
@@ -105,10 +105,13 @@ Assuming that your have a **api/controllers/UserController/js** file and a **api
 Another common target is one that binds a route to a [view](http://beta.sailsjs.org/#/documentation/concepts/Views).  The syntax for this is simple: it's the path to the view file relative to the **views** folder, without the file extension:
 
 ```
-'GET /home': 'home/index'
+'GET /home': {view: 'home/index'}
 ```
 
 This maps the `GET /home` to the view stored in **views/home/index.ejs** (assuming the default EJS [template engine](http://beta.sailsjs.org/#/documentation/concepts/Views/ViewEngines.html) is used).  As long as that view file exists, a **GET** request to  **/home** will display it.
+
+> Note that this route will be bound directly to the view, no policies will be applied in this case.
+> See the StackOverflow [question](http://stackoverflow.com/questions/21303217/sailsjs-policy-based-route-with-a-view/21340313#21340313) for more information.
 
 #### Blueprint target syntax
 


### PR DESCRIPTION
this is not a valid route: 'GET /home': 'home/index'
i tested above in sails 0.10.2 (currently available on npm), i also poked around in ./sails/lib/router/bind.js and it doesnt appear to handle string route to view.
changed to : 'GET /home': {view: 'home/index'}

also added in a note for issue #194
