### PR TITLE
Fix bubbles to show the proper types

### DIFF
--- a/reference/blueprint-api/Create.md
+++ b/reference/blueprint-api/Create.md
@@ -31,13 +31,13 @@ If the action is triggered via a socket request, the requesting socket will ALSO
     <tr>
       <td><code>&#42;</code></td>
       <td>
-        <bubble>string</bubble>
+        <bubble type="string" colors="bubble.color"></bubble>
         <br/>
-        <bubble>number</bubble>
+        <bubble type="number" colors="bubble.color"></bubble>
         <br/>
-        <bubble>object</bubble>
+        <bubble type="object" colors="bubble.color"></bubble>
         <br/>
-        <bubble>array</bubble>
+        <bubble type="array" colors="bubble.color"></bubble>
       </td>
       <td>
 
@@ -50,7 +50,7 @@ If the action is triggered via a socket request, the requesting socket will ALSO
       <td>
         <code>callback</code>
       </td>
-      <td><bubble>string</bubble></td>
+      <td><bubble type="string" colors="bubble.color"></bubble></td>
       <td>
         If specified, a JSONP response will be sent (instead of JSON).  This is the name of the client-side javascript function to call, passing results as the first (and only argument
 

--- a/reference/blueprint-api/Destroy.md
+++ b/reference/blueprint-api/Destroy.md
@@ -31,11 +31,11 @@ Consequently, all sockets currently subscribed to the instance will be unsubscri
         <em>(required)</em>
       </td>
       <td>
-        <bubble>number</bubble>
+        <bubble type="number" colors="bubble.color"></bubble>
         <br/>
         <em>-or-</em>
         <br/>
-        <bubble>string</bubble>
+        <bubble type="string" colors="bubble.color"></bubble>
       </td>
       <td>
 
@@ -50,7 +50,7 @@ Consequently, all sockets currently subscribed to the instance will be unsubscri
       <td>
         <code>callback</code>
       </td>
-      <td><bubble>string</bubble></td>
+      <td><bubble type="string" colors="bubble.color"></bubble></td>
       <td>
         if specified, a JSONP response will be sent (instead of JSON).  This is the name of the client-side javascript function to call, passing the result as the first (and only) argument
 

--- a/reference/blueprint-api/FindOne.md
+++ b/reference/blueprint-api/FindOne.md
@@ -57,11 +57,11 @@ If the action was triggered via a socket request, the requesting socket will be 
         <em>(required)</em>
       </td>
       <td>
-        <bubble>number</bubble>
+        <bubble type="number" colors="bubble.color"></bubble>
         <br/>
         <em>-or-</em>
         <br/>
-        <bubble>string</bubble>
+        <bubble type="string" colors="bubble.color"></bubble>
       </td>
       <td>
 
@@ -81,7 +81,7 @@ If the action was triggered via a socket request, the requesting socket will be 
       <td>
         <code>callback</code>
       </td>
-      <td><bubble>string</bubble></td>
+      <td><bubble type="string" colors="bubble.color"></bubble></td>
       <td>
         if specified, a JSONP response will be sent (instead of JSON).  This is the name of the client-side javascript function to call, passing the result as the first (and only) argument
 

--- a/reference/blueprint-api/Update.md
+++ b/reference/blueprint-api/Update.md
@@ -26,11 +26,11 @@ Updates the model instance which matches the **id** parameter.  Responds with a 
         <em>(required)</em>
       </td>
       <td>
-        <bubble>number</bubble>
+        <bubble type="number" colors="bubble.color"></bubble>
         <br/>
         <em>-or-</em>
         <br/>
-        <bubble>string</bubble>
+        <bubble type="string" colors="bubble.color"></bubble>
       </td>
       <td>
 
@@ -49,13 +49,13 @@ Updates the model instance which matches the **id** parameter.  Responds with a 
     <tr>
       <td><code>&#42;</code></td>
       <td>
-        <bubble>string</bubble>
+        <bubble type="string" colors="bubble.color"></bubble>
         <br/>
-        <bubble>number</bubble>
+        <bubble type="number" colors="bubble.color"></bubble>
         <br/>
-        <bubble>object</bubble>
+        <bubble type="object" colors="bubble.color"></bubble>
         <br/>
-        <bubble>array</bubble>
+        <bubble type="array" colors="bubble.color"></bubble>
       </td>
       <td>
 
@@ -67,7 +67,7 @@ Updates the model instance which matches the **id** parameter.  Responds with a 
       <td>
         <code>callback</code>
       </td>
-      <td><bubble>string</bubble></td>
+      <td><bubble type="string" colors="bubble.color"></bubble></td>
       <td>
         If specified, a JSONP response will be sent (instead of JSON).  This is the name of the client-side javascript function to call, passing results as the first (and only argument
 


### PR DESCRIPTION
The bubbles weren't working because the directive wasn't used correctly. I fixed that for all the usages.

Fixes balderdashy/www.sailsjs.org#45
Needs balderdashy/www.sailsjs.org#46 to be merged as well.
