### PR TITLE
Add documentation for config/env folder. Fixes #272

### DIFF
--- a/anatomy/myApp/config/env/development.js.md
+++ b/anatomy/myApp/config/env/development.js.md
@@ -1,0 +1,33 @@
+# myApp/config/env/development.js
+### Purpose
+This file will be loaded when Sails is running in `development` mode. Sails runs in `development` mode by default if no other environment is specified.
+
+<docmeta name="uniqueID" value="developmentjs874591">
+<docmeta name="displayName" value="development.js">
+
+```
+/**
+ * Development environment settings
+ *
+ * This file can include shared settings for a development team,
+ * such as API keys or remote database passwords.  If you're using
+ * a version control solution for your Sails app, this file will
+ * be committed to your repository unless you add it to your .gitignore
+ * file.  If your repository will be publicly viewable, don't add
+ * any private information to this file!
+ *
+ */
+
+module.exports = {
+
+  /***************************************************************************
+   * Set the default database connection for models in the development       *
+   * environment (see config/connections.js and config/models.js )           *
+   ***************************************************************************/
+
+  // models: {
+  //   connection: 'someMongodbServer'
+  // }
+
+};
+```

--- a/anatomy/myApp/config/env/env.md
+++ b/anatomy/myApp/config/env/env.md
@@ -1,0 +1,6 @@
+# myApp/config/env
+### Purpose
+This folder contains various environment settings such as API keys or remote database passwords. The environment file used is determined by the environment Sails is going to be running in. Sails loads environments settings into the `sails.config.environment` global object. To switch between different environments, see the [Sails CLI docs](http://sailsjs.org/#/documentation/reference/cli/sailslift.html).
+
+<docmeta name="uniqueID" value="envmd458963">
+<docmeta name="displayName" value="env">

--- a/anatomy/myApp/config/env/production.js.md
+++ b/anatomy/myApp/config/env/production.js.md
@@ -1,0 +1,47 @@
+# myApp/config/env/production.js
+### Purpose
+This file will be loaded when Sails is running in `production` mode. If using the CLI command `sails lift --prod`, these settings will be loaded.
+
+<docmeta name="uniqueID" value="productionjs658723">
+<docmeta name="displayName" value="production.js">
+
+```
+/**
+ * Production environment settings
+ *
+ * This file can include shared settings for a production environment,
+ * such as API keys or remote database passwords.  If you're using
+ * a version control solution for your Sails app, this file will
+ * be committed to your repository unless you add it to your .gitignore
+ * file.  If your repository will be publicly viewable, don't add
+ * any private information to this file!
+ *
+ */
+
+module.exports = {
+
+  /***************************************************************************
+   * Set the default database connection for models in the production        *
+   * environment (see config/connections.js and config/models.js )           *
+   ***************************************************************************/
+
+  // models: {
+  //   connection: 'someMysqlServer'
+  // },
+
+  /***************************************************************************
+   * Set the port in the production environment to 80                        *
+   ***************************************************************************/
+
+  // port: 80,
+
+  /***************************************************************************
+   * Set the log level in production environment to "silent"                 *
+   ***************************************************************************/
+
+  // log: {
+  //   level: "silent"
+  // }
+
+};
+```


### PR DESCRIPTION
Add in documentation for the `config/env` folder and how they are loaded into Sails. 
