### PR TITLE
Add a word on URL-encoding CSRF tokens when needed

### DIFF
--- a/concepts/Security/CSRF.md
+++ b/concepts/Security/CSRF.md
@@ -69,6 +69,13 @@ $.post('/checkout', {
 }, function andThen(){ ... });
 ```
 
+With some client-side modules, you may not have access to the AJAX request itself. In this case, you can consider sending the CSRF token directly in the URL of your query. However, if you do so, remember to URL-encode the token before spending it:
+```js
+..., {
+  checkoutAction: '/checkout?_csrf='+encodeURIComponent('USER_CSRF_TOKEN')
+}
+```
+
 
 
 ### Notes


### PR DESCRIPTION
Hi!
This is a minor addition related to the issue I posted at https://github.com/balderdashy/sails/issues/2266.
Just in case someone else has the same problem in the future.
Thanks @sgress454 for your help.
