### PR TITLE
Documented the `mirror` option

### DIFF
--- a/anatomy/myApp/config/blueprints.js.md
+++ b/anatomy/myApp/config/blueprints.js.md
@@ -124,7 +124,18 @@ module.exports.blueprints = {
   // POST   /foos
   // PUT    /foos/:id?
   // DELETE /foos/:id?
-  pluralize: false
+  pluralize: false,
+  
+  
+  // Whether to send pub/sub socket (or 'comet') events to the client they originated from.
+  //
+  // If `mirror` is false, then the client making the requests (for example, to update a record)
+  // will not receive the associated resourceful pub/sub events (for example 'updated'). However,
+  // all other subscribed client's will receive the event.
+  //
+  // If `mirror` is true, the client making requests WILL receive the associated resourceful
+  // pub/sub events, along will all other subscribed clients.
+  mirror: false
 
 };
 


### PR DESCRIPTION
There is no documentation for the `mirror` option.

This has cost me a lot of debugging time in the past.

I would also recommend the default to be true. I suspect most people building client-side apps would assume that behavior of Sails.