### PR TITLE
Removed Plugins in reference index

### DIFF
--- a/concepts/0home/0home.md
+++ b/concepts/0home/0home.md
@@ -7,28 +7,22 @@
   1. Default Tasks
   2. Disabling Grunt
   3. Task Automation
-2. **CORS**
-3. **Configuration**
+2. **Configuration**
   1. Using `.sailsrc` Files
-4. **Controllers**
-5. **Custom Responses**
-6. **Deployment**
+3. **Controllers**
+4. **Custom Responses**
+5. **Deployment**
   1. FAQ
   2. Hosting
   3. Scaling
-7. **File Uploads**
-8. **Globals**
-9. **Internationalization**
-10. **Logging**
-  1. sails.log
-11. **Middleware**
-12. **Models**
-  1. Attributes
-  2. Lifecycle callbacks
-  3. Model configuration
-  4. Query language
-  5. Validations
-  6. Model Associations
+6. **File Uploads**
+7. **Globals**
+8. **Internationalization**
+9. **Logging**
+  1. `sails.log()`
+10. **Middleware**
+11. **Models**
+  1. Associations
     1. Dominance
     2. Many-to-Many
     3. One Way Association
@@ -36,60 +30,38 @@
     5. One-to-One
     6. Through Associations
     7. Accessing Join Tables
-  7. Model Methods
-    1. .publishUpdate()
-    2. .add()
-    3. .create()
-    4. .destroy()
-    5. .exec()
-    6. .find()
-    7. .findOne()
-    8. .findOrCreate()
-    9. .limit()
-    10. .message()
-    11. .native()
-    12. .populate()
-    13. .publishAdd()
-    14. .publishCreate()
-    15. .publishDestroy()
-    16. .publishRemove()
-    17. .count()
-    18. .query()
-    19. .remove()
-    20. .save()
-    21. .skip()
-    22. .sort()
-    23. .stream()
-    24. .subscribe()
-    25. .toJSON()
-    26. .toObject()
-    27. .unsubscribe()
-    28. .unwatch()
-    29. .update()
-    30. .validate()
-    31. .watch()
-    32. .where()
-13. **Policies**
-14. **Routes**
-  1. Route Target Syntax
+  2. Attributes
+  3. Lifecycle callbacks
+  4. Models
+  5. Query language
+  6. Validations
+  8. Model Settings
+12. **Policies**
+13. **Routes**
+  1. Custom Routes
   2. URL Slugs
-15. **Security**
-  1. CSRF
-  2. Clickjacking
-  3. Content Security Policy
-  4. DDOS
-  5. P3P
-  6. Socket Hijacking
-  7. Strict Transport Security
-  8. XSS
-16. **Services**
-17. **Testing**
-18. **Upgrading**
-19. **Views**
+14. **Security**
+  1. CORS
+  2. CSRF
+  3. Clickjacking
+  4. Content Security Policy
+  5. DDOS
+  6. P3P
+  7. Socket Hijacking
+  8. Strict Transport Security
+  9. XSS
+15. **Services**
+16. **Testing**
+17. **Upgrading**
+18. **Views**
   1. Layouts
   2. Locals
   3. Partials
   4. View Engines
+19. Extending Sails
+  1. Adapters
+  2. Generators
+  3. Hooks
 
 
 <docmeta name="uniqueID" value="home198259">

--- a/reference/0home/0home.md
+++ b/reference/0home/0home.md
@@ -9,24 +9,14 @@
   3. Find Records
   4. Find One Record
   5. Update a Record
-2. **Plugins**
-  1. Adapters
-    1. Available Adapters
-    2. Custom Adapters
-  2. Generators
-    1. Custom Genarators
-    2. Available Generators
-  3. Hooks
-    1. Custom Hooks
-    2. Available Hooks
-3. **Command Line Interface**
+2. **Command Line Interface**
   1. sails console
   2. sails debug
   3. sails generate
   4. sails lift
   5. sails new
   6. sails version
-4. **Request** (`req`)
+3. **Request** (`req`)
   1. req.is()
   2. req.accepted()
   3. req.acceptedLanguages()
@@ -57,7 +47,7 @@
   28. req.url
   29. req.wantsJSON
   30. req.xhr
-5. **Response** (`res`)
+4. **Response** (`res`)
   1. res.negotiate()
   2. res.attachment()
   3. res.clearCookie()
@@ -77,7 +67,7 @@
   17. res.status()
   18. res.type()
   19. res.view()
-6. **Configuration**
+5. **Configuration**
   1. sails.config.i18n
   2. sails.config.blueprints
   3. sails.config.connections
@@ -93,14 +83,14 @@
   13. sails.config.session
   14. sails.config.sockets
   15. sails.config.views
-7. **Socket Client**
+6. **Socket Client**
   1. io.socket.on()
   2. io.socket.delete()
   3. io.socket.get()
   4. io.socket.post()
   5. io.socket.put()
   6. io.socket.request()
-8. **sails.sockets**
+7. **sails.sockets**
   1. sails.sockets.leave()
   2. sails.sockets.blast()
   3. sails.sockets.emit()


### PR DESCRIPTION
Plugins subject in reference index links to non existent content. Since generators are explained in CLI section and adapters and hooks appear as concepts, I suggest removing this subject from index, at least until more content about generators, adapters and hooks is written.