### PR TITLE
req.body returns undefined if not provided

### DIFF
--- a/reference/req/req.body.md
+++ b/reference/req/req.body.md
@@ -1,6 +1,6 @@
 # req.body
 
-An object containing text parameters from the parsed request body, defaulting to `{}`.
+An object containing text parameters from the parsed request body, defaulting to `undefined`.
 
 By default, the request body can be url-encoded or stringified as JSON.  Support for other formats, such as serialized XML, is possible using the [middleware](http://beta.sailsjs.org/#/documentation/concepts/Middleware) configuration.
 


### PR DESCRIPTION
Empirically tested in 0.10.5, that req.body is `undefined`, not `{}`.
Relevant code (I think): https://github.com/balderdashy/sails/blob/master/lib/app/request.js#L153