### PR TITLE
Added line break to format correctly for website.

### DIFF
--- a/reference/sails.config/sails.config.session.md
+++ b/reference/sails.config/sails.config.session.md
@@ -43,6 +43,7 @@ Uncomment the following lines to use your Mongo adapter as a session store
         db: 'sails',
         collection: 'sessions',
 ```
+
 Optional Values:
 ```javascript
         // Note: url will override other connection settings


### PR DESCRIPTION
On the docs html page for this entry, the "optional values" section is not being formatted correctly, I believe adding this break will fix that.