### PR TITLE
Unit of cache is in milliseconds as opposed to seconds.

### DIFF
--- a/reference/sails.config/sails.config.http.md
+++ b/reference/sails.config/sails.config.http.md
@@ -9,7 +9,7 @@ Configuration for your app's underlying HTTP server.  These properties are conve
  ------------------ |:----------:| --------- | -------
  `middleware`       | ((object)) | See [conventional defaults for HTTP middleware](http://beta.sailsjs.org/#/documentation/concepts/Middleware?q=conventional-defaults) | A configuration object of all HTTP middleware functions your app will run on every incoming HTTP request.  All [Express](https://github.com/expressjs/) or Connect middleware is supported.<br/>[Example](https://gist.github.com/mikermcneil/9cbd68c95839da480e97)
  `middleware.order` | ((array))  | See [conventional defaults for HTTP middleware order](https://github.com/balderdashy/sails/blob/master/lib/hooks/http/index.js#l51-66) | The order in which middleware should be run for HTTP request (the Sails router, which runs the appropriate explicit routes, policies, controllers, etc. from your app is invoked by the "router" middleware).
- `cache`            | ((number)) | `cache: 31557600000` | The number of seconds to cache flat files on disk being served by Express static middleware (by default, these files are in `.tmp/public`)<br/>The HTTP static cache is only active in a 'production' environment (default 1 year), since that's the only time Express will cache flat-files.
+ `cache`            | ((number)) | `cache: 31557600000` | The number of milliseconds to cache flat files on disk being served by Express static middleware (by default, these files are in `.tmp/public`)<br/>The HTTP static cache is only active in a 'production' environment (default 1 year), since that's the only time Express will cache flat-files.
  `serverOptions`    | ((object)) | TODO      | TODO
 
 


### PR DESCRIPTION
W3C says max-age should be in seconds, Static middleware says it takes milliseconds as the input and output into seconds. Confusing.