### PR TITLE
Fixes One-to-one association reference

### DIFF
--- a/concepts/ORM/Associations/OnetoOne.md
+++ b/concepts/ORM/Associations/OnetoOne.md
@@ -7,8 +7,7 @@ record.
 
 ### One-to-One Example
 
-In this example, we are associating a `Pet` with a `User`. The `User` may only have one `Pet` in
-this case but a `Pet` is not limited to a single `User`.
+In this example, we are associating a `Pet` with a `User`. The `User` may only have one `Pet` and viceversa, a `Pet` can only have one `User`. However, in order to query this association from both sides, you will have to create/update both models.
 
 
 `myApp/api/models/pet.js`


### PR DESCRIPTION
The *one-to-one* association was referencing the behavior of a one-way association. If I understand correctly, as long as you define a model association on both models, that makes it *one-to-one* (**bidirectional**). If you only define the model in one model that makes it *one-to-one*(**unidirectional**). Maybe I'm misunderstanding something based on [this waterline documenation](https://github.com/balderdashy/waterline-docs/blob/master/associations.md)