### PR TITLE
Remove confusing dominant property

### DIFF
--- a/concepts/ORM/Associations/ManytoMany.md
+++ b/concepts/ORM/Associations/ManytoMany.md
@@ -35,8 +35,7 @@ module.exports = {
 		// Add a reference to User
 		owners: {
 			collection: 'user',
-			via: 'pets',
-			dominant:true
+			via: 'pets'
 		}
 	}
 }


### PR DESCRIPTION
The Many-to-Many example contains an unnecessary `dominant` property which is confusing as the example is  not a cross-adapter/cross-connection association. 