### PR TITLE
Add small section on custom validation message hook

### DIFF
--- a/concepts/ORM/Validations.md
+++ b/concepts/ORM/Validations.md
@@ -118,7 +118,37 @@ module.exports = {
  ```
 
 
+### Custom Validation Messages
+Out of the box, Sails.js does not support custom validation messages. However, for Sails v0.11.0+ a [Hook](http://sailsjs.org/#!/documentation/concepts/extending-sails/Hooks) is available: [sails-hook-validator](https://github.com/lykmapipo/sails-hook-validation). 
 
+#### Usage
+- Add `validationMessages` static property in your sails model
+```js
+//this is example
+module.exports = {
+    attributes: {
+        username: {
+            type: 'string',
+            required: true
+        },
+        email: {
+            type: 'email',
+            required: true
+        }
+    },
+    //model validation messages definitions
+    validationMessages: { //hand for i18n & l10n
+        email: {
+            required: 'Email is required',
+            email: 'Provide valid email address',
+            unique: 'Email address is already taken'
+        },
+        username: {
+            required: 'Username is required'
+        }
+    }
+};
+```
 
 <docmeta name="uniqueID" value="Validations576587">
 <docmeta name="displayName" value="Validations">

--- a/concepts/ORM/Validations.md
+++ b/concepts/ORM/Validations.md
@@ -119,36 +119,8 @@ module.exports = {
 
 
 ### Custom Validation Messages
-Out of the box, Sails.js does not support custom validation messages. However, for Sails v0.11.0+ a [Hook](http://sailsjs.org/#!/documentation/concepts/extending-sails/Hooks) is available: [sails-hook-validator](https://github.com/lykmapipo/sails-hook-validation). 
+Out of the box, Sails.js does not support custom validation messages. However, for Sails v0.11.0+ a [Hook](http://sailsjs.org/#!/documentation/concepts/extending-sails/Hooks) is available: [sails-hook-validator](https://github.com/lykmapipo/sails-hook-validation). Details regarding its usage can be found in the [sails-hook-validator](https://github.com/lykmapipo/sails-hook-validation) repository.
 
-#### Usage
-- Add `validationMessages` static property in your sails model
-```js
-//this is example
-module.exports = {
-    attributes: {
-        username: {
-            type: 'string',
-            required: true
-        },
-        email: {
-            type: 'email',
-            required: true
-        }
-    },
-    //model validation messages definitions
-    validationMessages: { //hand for i18n & l10n
-        email: {
-            required: 'Email is required',
-            email: 'Provide valid email address',
-            unique: 'Email address is already taken'
-        },
-        username: {
-            required: 'Username is required'
-        }
-    }
-};
-```
 
 <docmeta name="uniqueID" value="Validations576587">
 <docmeta name="displayName" value="Validations">


### PR DESCRIPTION
Added a tiny section on supporting custom validation messages using [sails-hook-validator](https://github.com/lykmapipo/sails-hook-validation)