### PR TITLE
Remove incorrect links

### DIFF
--- a/anatomy/myApp/api/controllers/UserController.js.md
+++ b/anatomy/myApp/api/controllers/UserController.js.md
@@ -1,7 +1,7 @@
 # myApp/api/controllers/UserController.js
 ### Purposes
 
-This file was created when you ran 'sails generate api User'.  It contains all of the controller logic for the model called 'User'. 
+This file was created when you ran 'sails generate api User'.  It contains all of the controller logic for the model called 'User'.
 
 This is where you will put "controller actions" that send data to your clients and render the views which display that data.
 
@@ -13,11 +13,10 @@ This is where you will put "controller actions" that send data to your clients a
  * UserController
  *
  * @description :: Server-side logic for managing users
- * @help        :: See http://links.sailsjs.org/docs/controllers
  */
 
 module.exports = {
-	
+
 };
 
 

--- a/anatomy/myApp/api/models/User.js.md
+++ b/anatomy/myApp/api/models/User.js.md
@@ -2,9 +2,9 @@
 ### Purpose
 This file was created when you ran 'sails generate api User'.  It contains the structure for the model called 'User'.
 
-In this file you will specify what attributes each model instance (record) should have.  You can also add custom model instance methods, as well as override the global settings for things like `policies` and `connections`.  
+In this file you will specify what attributes each model instance (record) should have.  You can also add custom model instance methods, as well as override the global settings for things like `policies` and `connections`.
 
-One of the best parts about Sails is it uses [Waterline](https://github.com/balderdashy/waterline).  This means you can start developing your data models long before you commit to a particular database. 
+One of the best parts about Sails is it uses [Waterline](https://github.com/balderdashy/waterline).  This means you can start developing your data models long before you commit to a particular database.
 
 <docmeta name="uniqueID" value="Userjs263218">
 <docmeta name="displayName" value="User.js">
@@ -14,7 +14,6 @@ One of the best parts about Sails is it uses [Waterline](https://github.com/bald
 * User.js
 *
 * @description :: TODO: You might write a short summary of how this model works and what it represents here.
-* @docs        :: http://sailsjs.org/#!documentation/models
 */
 
 module.exports = {


### PR DESCRIPTION
Both of these links auto-generated by Sails are broken (one no longer resolves, the other redirects to a generic table of contents page). Rather than add to the existing 69,000 broken auto-generated Sails links, figure it would be better to remove the links.

https://github.com/search?utf8=%E2%9C%93&q=%22http%3A%2F%2Fsailsjs.org%2F%23%21documentation%22&type=Code&ref=searchresults