### PR TITLE
Fixed broken links to OWASP

### DIFF
--- a/concepts/Security/XSS.md
+++ b/concepts/Security/XSS.md
@@ -5,8 +5,8 @@ Cross-site scripting (XSS) is a type of attack in which a malicious agent manage
 
 
 ### Additional Resources
-+ [XSS (OWasp)](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS))
-+ [XSS Prevention Cheatsheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet)
++ [XSS (OWasp)](https://www.owasp.org/index.php/Cross-site_Scripting_\(XSS\))
++ [XSS Prevention Cheatsheet](https://www.owasp.org/index.php/XSS_\(Cross_Site_Scripting\)_Prevention_Cheat_Sheet)
 
 <docmeta name="uniqueID" value="XSS397141">
 <docmeta name="displayName" value="XSS">


### PR DESCRIPTION
Links look fine in GitHub preview, but are broken (the parentheses are misinterpreted) on http://sailsjs.org/#!/documentation/concepts/Security/XSS.html.