### PR TITLE
Fixing a case typo

### DIFF
--- a/concepts/Testing/Testing.md
+++ b/concepts/Testing/Testing.md
@@ -45,7 +45,7 @@ before(function(done) {
 
 after(function(done) {
   // here you can clear fixtures, etc.
-  sails.lower(done);
+  Sails.lower(done);
 });
 ```
 


### PR DESCRIPTION
The bootstrap.test.js had sails.lower(done) when it should be Sails.lower(done).