### PR TITLE
Increased the timeout in bootstrap.test.js example

### DIFF
--- a/concepts/Testing/Testing.md
+++ b/concepts/Testing/Testing.md
@@ -33,6 +33,9 @@ var Sails = require('sails'),
   sails;
 
 before(function(done) {
+
+  this.timeout(5000);
+
   Sails.lift({
     // configuration for testing purposes
   }, function(err, server) {

--- a/concepts/Testing/Testing.md
+++ b/concepts/Testing/Testing.md
@@ -34,6 +34,7 @@ var Sails = require('sails'),
 
 before(function(done) {
 
+  // Increase the Mocha timeout so that Sails has enough time to lift.
   this.timeout(5000);
 
   Sails.lift({


### PR DESCRIPTION
The standard 2000ms is not always long enough to lift Sails. With a timeout in place it is easy to see how to change it if there is a timeout error.