### PR TITLE
new adapter for FileMaker Databases

### DIFF
--- a/status/plugins/adapters.js
+++ b/status/plugins/adapters.js
@@ -93,6 +93,10 @@ module.exports = {
 		repo: 'https://github.com/appscot/sails-orientdb',
 		status: 'edge'
 	},
+	'sails-filemaker': {
+		repo: 'https://github.com/geistinteractive/sails-filemaker',
+		status: 'edge'
+	}
 
 
 


### PR DESCRIPTION
Hello,

I wrote an adaptor for FileMaker databases.  The semantic interface was all I needed. It is passing all the tests in that interface except for the types that don't apply.  You can't make schema changes with this adaptor.  

Not sure what 'status' should be.  Although it passes the semantic test suite it's still new. There are probably some bugs.

Thanks

Todd

PS. this is my first pull request on github.  not sure if I am doing it correctly :-)