### PR TITLE
Add dynamicFinders

### DIFF
--- a/reference/sails.config/sails.config.models.md
+++ b/reference/sails.config/sails.config.models.md
@@ -18,6 +18,7 @@ sails.config.models;
  `autoCreatedAt`       | ((boolean))  | `true`             | Toggle the automatic definition of a property createdAt in your model
  `autoUpdatedAt`       | ((boolean))  | `true`             | Toggle the automatic definition of a property updatedAt in your model
  `tableName`           | ((string))   | _identity_       | Used to specify database table name for the model
+ `dynamicFinders`      | ((boolean))  | `true`             | Toggle the automatic creation of Dynamic Finders 
 
 
 <docmeta name="uniqueID" value="sailsconfigmodels258825">


### PR DESCRIPTION
As per issue https://github.com/balderdashy/waterline/issues/592#issuecomment-113427311
Ability to toggle creation of dynamicFinders has been added, missing in docs.