### PR TITLE
Document api/hooks/file.js alternative

### DIFF
--- a/concepts/extending-sails/Hooks/userhooks.md
+++ b/concepts/extending-sails/Hooks/userhooks.md
@@ -11,6 +11,8 @@ To create a new user hook:
 
 Your new folder may contain other files as well, which can be loaded in your hook via `require`; only `index.js` will be read automatically by Sails.
 
+As an alternative to a folder, you may create a file in your app&rsquo;s `api/hooks` folder like `api/hooks/myUserHook.js`.
+
 #### Testing that your hook loads properly
 
 To test that your hook is being loaded by Sails, lift your app with `sails lift --verbose`.  If your hook is loaded, you will see a message like:


### PR DESCRIPTION
The Sails code allows a js file in the `api/hooks` directory without a subfolder. Some users (and myself) might prefer to have the `api/hooks` directory full of files instead of have a bunch of folders with one `index.js` file in them. It seems worth mentioning in the documentation.