### PR TITLE
`record` param is optional

### DIFF
--- a/reference/waterline/models/findOrCreate.md
+++ b/reference/waterline/models/findOrCreate.md
@@ -1,4 +1,4 @@
-# .findOrCreate( `criteria` , `record` , [`callback`] )
+# .findOrCreate( `criteria` , [`record`] , [`callback`] )
 ### Purpose
 Checks for the existence of the record in the first parameter.  If it can't be found, the record in the second parameter is created.
 


### PR DESCRIPTION
According to the [code](https://github.com/balderdashy/waterline/blob/v0.10.24/lib/waterline/query/composite.js#L27) the `record` parameter is optional and can be the callback.