### PR TITLE
Add a note to make the timeout setting in mocha.opts

### DIFF
--- a/concepts/Testing/Testing.md
+++ b/concepts/Testing/Testing.md
@@ -58,6 +58,10 @@ This file should contain mocha configuration as described here: [mocha.opts](htt
 --require coffee-script/register
 --compilers coffee:coffee-script/register
 ```
+**Note**: The default test-case timeout in Mocha is 2 seconds. Increase the timeout value in mocha.opts to make sure the sails lifting completes before any of the test-cases can be started. For example:
+```
+--timeout 5s
+```
 
 ## Writing tests
 


### PR DESCRIPTION
Add a note to make the timeout setting in mocha.opts. Otherwise, the test case will always be failing since sails lifting typically completes longer than 2 seconds.

Here is the error I got:
```
1) "before all" hook

  0 passing (3s)
  1 failing

  1)  "before all" hook:
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```