### PR TITLE
for posterity

### DIFF
--- a/reference/waterline/populated-values/add.md
+++ b/reference/waterline/populated-values/add.md
@@ -54,6 +54,7 @@ User.find({name:'Mike'}).populate('pets').exec(function(e,r){
 > + .add() does not accept arrays of any kind.  Don't try it.
 > + Any string arguments passed must be the primary key of the record.
 > + `.add()` alone won't actually persist the change in associations to the databse.  You should call `.save()` after using `.add()` or `.remove()`.
+> + Attempting to add an association that already exists will throw an error. [See here for an example.](https://github.com/balderdashy/waterline/issues/352)
 
 
 <docmeta name="uniqueID" value="add574043">


### PR DESCRIPTION
I spent much minutes (so time! wow.) cursing waterline's `add` method.

Why, you ask?

Well, if you attempt to add a record to a collection and that record is already in the collection, waterline throws an error. It's one of those things where someone you love does something and you still love them but why did they do that, you know?

My explanation above was kind of bad, though, so just [see this issue](https://github.com/balderdashy/waterline/issues/352) 

**tl;dr This one's for posterity.** Added a warning to the docs re: the above Issue