### PR TITLE
Return response in format consistant with .find()

### DIFF
--- a/reference/waterline/models/query.md
+++ b/reference/waterline/models/query.md
@@ -8,7 +8,7 @@
 ```js
 Pet.query('SELECT pet.name FROM pet', function(err, results) {
   if (err) return res.serverError(err);
-  return res.ok(results);
+  return res.ok(results.rows);
 });
 ```
 


### PR DESCRIPTION
`return res.ok(results); `
sends back JSON with info about the query and requires different handling than the default responses of the blueprint methods like 
`.find().  `
changing to results.rows produces consistent output.