### PR TITLE
Update docs to show correct email attribute

### DIFF
--- a/concepts/ORM/Attributes.md
+++ b/concepts/ORM/Attributes.md
@@ -34,8 +34,9 @@ Checks the incoming value for a valid email address.
 ```javascript
 attributes: {
   email: {
-    type: 'string',
-    email: true
+    type: 'email',
+    unique: true,
+    columnName: 'email_address'
   }
 }
 ```


### PR DESCRIPTION
Current email attribute `type: 'string'` does not work and give an error