### PR TITLE
Correct email example and include missing type

### DIFF
--- a/concepts/ORM/Attributes.md
+++ b/concepts/ORM/Attributes.md
@@ -27,18 +27,7 @@ Specifies the type of data that will be stored in this attribute.  One of:
 - binary
 - array
 - json
-
-###### email
-Checks the incoming value for a valid email address.
-
-```javascript
-attributes: {
-  email: {
-    type: 'string',
-    email: true
-  }
-}
-```
+- email
 
 ###### defaultsTo
 


### PR DESCRIPTION
This will cause errors with valid email addresses for some reason:

type: 'string',
email: true

Instead you should use the following:

type: 'email'

You can reference the following issue for more information on this:

https://github.com/balderdashy/sails/issues/3034