### PR TITLE
updated "Tutorial on how to implement passport.js with sails.js" link

### DIFF
--- a/concepts/Policies/SailsAndPassport.md
+++ b/concepts/Policies/SailsAndPassport.md
@@ -3,9 +3,9 @@
 Passport works great with Sails!  In general, since Sails uses Connect/Express at its core, all of the Connect/Express-oriented things work pretty well.  In fact, Sails has no problem interpreting most Express middleware to work with socket.io.
 
 #### Community-supported Sails extensions using passport.js
++ [Tutorial on how to implement passport.js with sails.js](http://iliketomatoes.com/implement-passport-js-authentication-with-sails-js-0-10-2/).
 + [sails-auth](https://www.npmjs.com/package/sails-auth): Passport-based Authentication Extension, including Basic Auth
 + [sails-permissions](https://www.npmjs.com/package/sails-permissions): Permissions and Entitlements system for sails.js: supports user authentication with passport.js, role-based permissioning, object ownership, and row-level security.
-+ [Tutorial on how to implement passport.js with sails.js](http://www.geektantra.com/2013/08/implement-passport-js-authentication-with-sails-js/).
 + [Waterlock](http://waterlock.ninja/): An all encompassing user authentication/json web token management tool, built for Sails
 
 


### PR DESCRIPTION
The existing tutorial is full of errors. Was unable to get it to work. This "how to" link however is error free and gets the concepts across clearly. Also sails-auth says it is deprecated. 

Also changed order because using passport.js is the simplest way to get auth to work for beginners.