### PR TITLE
fixed autoconnect -> autoConnect

### DIFF
--- a/reference/websockets/sails.io.js/SailsSocket/SailsSocket.md
+++ b/reference/websockets/sails.io.js/SailsSocket/SailsSocket.md
@@ -12,7 +12,7 @@ The `sails.io.js` library works by wrapping low-level [Socket.io](http://socket.
 
 ### Creating a SailsSocket instance
 
-Any web page which loads the `sails.io.js` will create a new SailsSocket instance on page load unless [`io.sails.autoconnect`](http://sailsjs.org/documentation/reference/web-sockets/socket-client/io-sails#?autoconnect) is set to `false`.  This instance is then available as the global variable [`io.socket`](http://sailsjs.org/documentation/reference/web-sockets/socket-client/io-socket).
+Any web page which loads the `sails.io.js` will create a new SailsSocket instance on page load unless [`io.sails.autoConnect`](http://sailsjs.org/documentation/reference/web-sockets/socket-client/io-sails#?autoconnect) is set to `false`.  This instance is then available as the global variable [`io.socket`](http://sailsjs.org/documentation/reference/web-sockets/socket-client/io-socket).
 
 Additional SailsSocket instances can be created via calls to [`io.sails.connect`](http://sailsjs.org/documentation/reference/web-sockets/socket-client/io-sails#?the-connect-method):
 


### PR DESCRIPTION
There was a typo - "autoconnect" was written in lower case but should be in camelCase as it is in the library code.