### PR TITLE
Replace 'jade' with 'pug'

### DIFF
--- a/concepts/Assets/Assets.md
+++ b/concepts/Assets/Assets.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-Assets refer to [static files](http://en.wikipedia.org/wiki/Static_web_page) (js, css, images, etc) on your server that you want to make accessible to the outside world. In Sails, these files are placed in the [`assets/`](http://sailsjs.org/documentation/anatomy/myApp/assets) directory, where they are processed and synced to a hidden temporary directory (`.tmp/public/`) when you lift your app. The contents of this `.tmp/public` folder are what Sails actually serves - roughly equivalent to the "public" folder in [express](https://github.com/expressjs), or the "www" folder you might be familiar with from other web servers like Apache.  This middle step allows Sails to prepare/pre-compile assets for use on the client - things like LESS, CoffeeScript, SASS, spritesheets, Jade templates, etc.
+Assets refer to [static files](http://en.wikipedia.org/wiki/Static_web_page) (js, css, images, etc) on your server that you want to make accessible to the outside world. In Sails, these files are placed in the [`assets/`](http://sailsjs.org/documentation/anatomy/myApp/assets) directory, where they are processed and synced to a hidden temporary directory (`.tmp/public/`) when you lift your app. The contents of this `.tmp/public` folder are what Sails actually serves - roughly equivalent to the "public" folder in [express](https://github.com/expressjs), or the "www" folder you might be familiar with from other web servers like Apache.  This middle step allows Sails to prepare/pre-compile assets for use on the client - things like LESS, CoffeeScript, SASS, spritesheets, Pug templates, etc.
 
 ### Static middleware
 

--- a/concepts/Assets/DisablingGrunt.md
+++ b/concepts/Assets/DisablingGrunt.md
@@ -10,7 +10,7 @@ To disable Grunt integration in Sails, simply delete your Gruntfile (and/or [`ta
 }
 ```
 
-### Can I customize this for SASS, Angular, client-side Jade templates, etc?
+### Can I customize this for SASS, Angular, client-side templates, etc?
 
 Yep! Just replace the relevant grunt task in your `tasks/` directory, or add a new one.  Like [SASS](https://github.com/sails101/using-sass) for example.
 

--- a/concepts/Views/Layouts.md
+++ b/concepts/Views/Layouts.md
@@ -2,7 +2,7 @@
 
 When building an app with many different pages, it can be helpful to extrapolate markup shared by several HTML files into a layout.  This [reduces the total amount of code](http://en.wikipedia.org/wiki/Don't_repeat_yourself) in your project and helps you avoid making the same changes in multiple files down the road.
 
-In Sails and Express, layouts are implemented by the view engines themselves.  For instance, `jade` has its own layout system, with its own syntax.
+In Sails and Express, layouts are implemented by the view engines themselves.  For instance, `pug` has its own layout system, with its own syntax.
 
 For convenience, Sails bundles special support for layouts **when using the default view engine, EJS**. If you'd like to use layouts with a different view engine, check out [that view engine's documentation](http://sailsjs.org/documentation/concepts/Views/ViewEngines.html) to find the appropriate syntax.
 
@@ -41,7 +41,7 @@ privacy: function (req, res) {
 >
 > Sails supports the legacy `layouts` feature for convenience, backwards compatibility with Express 2.x and Sails 0.8.x apps, and in particular, familiarity for new community members coming from other MVC frameworks. As a result, layouts have only been tested with the default view engine (ejs).
 >
-> If layouts aren&rsquo;t your thing, or (for now) if you&rsquo;re using a server-side view engine other than ejs, (e.g. Jade, handlebars, haml, dust) you&rsquo;ll want to set `layout:false` in [`sails.config.views`](http://sailsjs.org/documentation/reference/sails.config/sails.config.views.html), then rely on your view engine&rsquo;s custom layout/partial support.
+> If layouts aren&rsquo;t your thing, or (for now) if you&rsquo;re using a server-side view engine other than ejs, (e.g. pug, handlebars, haml, dust) you&rsquo;ll want to set `layout:false` in [`sails.config.views`](http://sailsjs.org/documentation/reference/sails.config/sails.config.views.html), then rely on your view engine&rsquo;s custom layout/partial support.
 
 
 

--- a/concepts/Views/ViewEngines.md
+++ b/concepts/Views/ViewEngines.md
@@ -6,7 +6,7 @@ The default view engine in Sails is [EJS](https://github.com/visionmedia/ejs).
 
 To use a different view engine, you should use npm to install it in your project, then set `sails.config.views.engine` in [`config/views.js`](http://sailsjs.org/documentation/anatomy/myApp/config/views.js.html).
 
-For example, to switch to jade, run `npm install jade --save-dev`, then set `engine: 'jade'` in [`config/views.js`](http://sailsjs.org/documentation/anatomy/myApp/config/views.js.html).
+For example, to switch to jade, run `npm install pug --save-dev`, then set `engine: 'pug'` in [`config/views.js`](http://sailsjs.org/documentation/anatomy/myApp/config/views.js.html).
 
 
 

--- a/concepts/Views/ViewEngines.md
+++ b/concepts/Views/ViewEngines.md
@@ -6,7 +6,7 @@ The default view engine in Sails is [EJS](https://github.com/visionmedia/ejs).
 
 To use a different view engine, you should use npm to install it in your project, then set `sails.config.views.engine` in [`config/views.js`](http://sailsjs.org/documentation/anatomy/myApp/config/views.js.html).
 
-For example, to switch to jade, run `npm install pug --save-dev`, then set `engine: 'pug'` in [`config/views.js`](http://sailsjs.org/documentation/anatomy/myApp/config/views.js.html).
+For example, to switch to pug (formerly jade), run `npm install pug --save-dev`, then set `engine: 'pug'` in [`config/views.js`](http://sailsjs.org/documentation/anatomy/myApp/config/views.js.html).
 
 
 
@@ -21,7 +21,7 @@ For example, to switch to jade, run `npm install pug --save-dev`, then set `engi
   - [haml-coffee](https://github.com/9elements/haml-coffee) [(website)](http://haml.info/)
   - [handlebars](https://github.com/wycats/handlebars.js/) [(website)](http://handlebarsjs.com/) (.hbs)
   - [hogan](https://github.com/twitter/hogan.js) [(website)](http://twitter.github.com/hogan.js/)
-  - [jade](https://github.com/visionmedia/jade) [(website)](http://jade-lang.com/) (.jade)
+  - [pug (formerly jade)](https://github.com/pugjs/pug) [(website)](http://jade-lang.com/) (.jade)
   - [jazz](https://github.com/shinetech/jazz)
   - [jqtpl](https://github.com/kof/node-jqtpl) [(website)](https://github.com/kof/jqtpl)
   - [JUST](https://github.com/baryshev/just)

--- a/reference/sails.config/sails.config.views.md
+++ b/reference/sails.config/sails.config.views.md
@@ -14,7 +14,7 @@ Configuration for your app's server-side [views](http://sailsjs.org/documentatio
 
 ### Notes
 
-> + If your app is NOT using `ejs` (the default view engine) Sails will function as if the `layout` option was set to `false`.  To take advantage of layouts when using a custom view engine like Jade or Handlebars, check out [that view engine's documentation](http://sailsjs.org/documentation/concepts/Views/ViewEngines.html) to find the appropriate syntax.
+> + If your app is NOT using `ejs` (the default view engine) Sails will function as if the `layout` option was set to `false`.  To take advantage of layouts when using a custom view engine like Pug or Handlebars, check out [that view engine's documentation](http://sailsjs.org/documentation/concepts/Views/ViewEngines.html) to find the appropriate syntax.
 > + As of Sails 0.12.0, app-wide locals from `sails.config.views.locals` are combined with any one-off locals you use with `res.view()` using a **shallow merge strategy**.  That is, if your app-wide locals configuration is `{foo: 3, bar: { baz: 'beep' } }`, and then you use `res.view({bar: 'boop'})`, your view will have access to `foo` (`3`) and `bar` (`'boop'`).
 
 
@@ -22,5 +22,3 @@ Configuration for your app's server-side [views](http://sailsjs.org/documentatio
 
 <docmeta name="displayName" value="sails.config.views">
 <docmeta name="pageType" value="property">
-
-


### PR DESCRIPTION
# _DO NOT MERGE_
This branch is a WIP.

## 🐶 
Jade was renamed to pug because of trademark yuckiness. We have to update our docs now ugghhhhhh.

## The question
Is the out-of-the-box jade view generator in Sails going away? Will it be renamed to pug? Am I just generally confused? 

(Could use some help from sails-core on this question. cc @mikermcneil @rachaelshaw)

## The strategery 
Seeing as this name change is a new development for jade, I think we should (for the time being) refer to _**pug** (formerly known as jade)_ whenever we can.

## toupdate

- [ ] myApp
- [ ] extending-sails (Generators)
- [ ] reference (Generators)
