### PR TITLE
save.md should reflect changes in sails v0.12

### DIFF
--- a/reference/waterline/records/save.md
+++ b/reference/waterline/records/save.md
@@ -8,14 +8,13 @@ The `save()` method updates your record in the database using the current attrib
 
 |   |     Description     | Accepted Data Types | Required ? |
 |---|---------------------|---------------------|------------|
-| 1 |     Callback        | `function`          | Yes        |
+| 1 |     Callback        | `function`          | No         |
 
 #### Callback Parameters
 
 |   |     Description     | Possible Data Types |
 |---|---------------------|---------------------|
 | 1 |  Error              | `Error`             |
-| 2 |  Saved Record       | `{ }`               |
 
 
 ### Example Usage
@@ -28,8 +27,8 @@ User.find().exec(
     var getOneRecord = myRecords.pop();
     getOneRecord.name = 'Hank';
     getOneRecord.save(
-      function(err,s){
-        console.log('User with ID '+s.id+' now has name '+s.name);
+      function(err){
+        console.log('User with ID '+getOneRecord.id+' now has name '+getOneRecord.name);
       });
   });
 


### PR DESCRIPTION
As of v0.12 `*.save(cb)` no longer passes the saved record to the `cb`.

Also, even though recommended, passing a cb to `*.save()` is not strictly Required.