### PR TITLE
Remove note not to try add()ing an array

### DIFF
--- a/reference/waterline/populated-values/add.md
+++ b/reference/waterline/populated-values/add.md
@@ -51,7 +51,6 @@ User.find({name:'Mike'}).populate('pets').exec(function(e,r){
 
 
 ### Notes
-> + .add() does not accept arrays of any kind.  Don't try it.
 > + Any string arguments passed must be the primary key of the record.
 > + `.add()` alone won't actually persist the change in associations to the databse.  You should call `.save()` after using `.add()` or `.remove()`.
 > + Attempting to add an association that already exists will throw an error. [See here for an example.](https://github.com/balderdashy/waterline/issues/352)


### PR DESCRIPTION
Page: http://sailsjs.org/documentation/reference/waterline-orm/populated-values/add

PR that added functionality: https://github.com/balderdashy/waterline/pull/1190/commits/93b45004a1b02c094477c1280c8c8e296ae6b9bc

Waterline docs for reference: https://github.com/balderdashy/waterline-docs/blob/master/models/associations/many-to-many.md#with-an-array-of-new-record

Issue about this line on this page: https://github.com/balderdashy/sails/issues/3733