### PR TITLE
Update save.md

### DIFF
--- a/reference/waterline/records/save.md
+++ b/reference/waterline/records/save.md
@@ -15,6 +15,7 @@ The `save()` method updates your record in the database using the current attrib
 |   |     Description     | Possible Data Types |
 |---|---------------------|---------------------|
 | 1 |  Error              | `Error`             |
+| 2 |  Sucessfully Saved Record | `{}`          
 
 
 ### Example Usage


### PR DESCRIPTION
In the Purpose section it says that the call back returns the newly saved object. Indeed it does, but the Callback Parameters section doesn't show it. It's confusing.

I've added it, following the style on the [.update()](http://sailsjs.org/documentation/reference/waterline-orm/models/update) page.