### PR TITLE
delete the second parameter when using the save() method at the sails…

### DIFF
--- a/reference/waterline/records/save.md
+++ b/reference/waterline/records/save.md
@@ -15,7 +15,6 @@ The `save()` method updates your record in the database using the current attrib
 |   |     Description     | Possible Data Types |
 |---|---------------------|---------------------|
 | 1 |  Error              | `Error`             |
-| 2 |  Sucessfully Saved Record | `{}`          
 
 
 ### Example Usage


### PR DESCRIPTION
…js latest version

In the sailsjs version 0.12, save method don`t provide the second parameter any more.