### PR TITLE
Fix errors in prepared statement docs

### DIFF
--- a/reference/waterline/models/query.md
+++ b/reference/waterline/models/query.md
@@ -16,7 +16,7 @@ Pet.query('SELECT pet.name FROM pet', function(err, results) {
 
 ```js
 Pet.query({
-  text: 'SELECT pet.name FROM pet WHERE pet.name = $1',
+  sql: 'SELECT pet.name FROM pet WHERE pet.name = ?',
   values: [ "dog" ]
 }, function(err, results) {
   if (err) return res.serverError(err);


### PR DESCRIPTION
Spent way too much time tracking this down...

I am using NodeJS 4 (4.4.7 LTS) with sails-mysql 0.11.5, and it turns out that the query object attribute needs to be named "sql" and the prepared statement syntax needs to use the (expected, typical) "?" placeholder for mysql.
