### PR TITLE
Fix an error in reference/res/res.created.md

### DIFF
--- a/reference/res/res.created.md
+++ b/reference/res/res.created.md
@@ -39,7 +39,7 @@ return res.created('New widget created.');
 With a custom view:
 
 ```javascript
-return res.forbidden(
+return res.created(
     'New widget created.',
     'widgets/created'
   );


### PR DESCRIPTION
Changed `return res.forbidden(` with `return res.created(` in line 42.