### PR TITLE
in query.md, make the reference to `.native()` a formatted link

### DIFF
--- a/reference/waterline/models/query.md
+++ b/reference/waterline/models/query.md
@@ -25,7 +25,7 @@ Pet.query({
 ```
 
 ### Notes
-> This method only works with PostgreSQL and mySQL! use .native() for Mongo.
+> This method only works with PostgreSQL and mySQL! use [`.native()`](http://sailsjs.org/documentation/reference/waterline-orm/models/native) for Mongo.
 
 > This method does not return a promise. [Refer here](http://stackoverflow.com/questions/21886630/how-to-use-model-query-with-promises-in-sailsjs-waterline) to promisify .query().
 


### PR DESCRIPTION
replaces #732 

per @rachaelshaw, this commit also links to the doucmentation at sailsjs.org instead of assuming that we'll be able to have relative links that work everywhere.