### PR TITLE
Custom hooks example

### DIFF
--- a/concepts/extending-sails/Hooks/hookspec/routes.md
+++ b/concepts/extending-sails/Hooks/hookspec/routes.md
@@ -8,9 +8,8 @@ module.exports = function (sails) {
     return {
 
         initialize: function (cb) {
-            const self = sails.hooks['count-requests'];
-            self.numRequestsSeen = 0;
-            self.numUnhandledRequestsSeen = 0;
+            this.numRequestsSeen = 0;
+            this.numUnhandledRequestsSeen = 0;
             return cb();
         },
 

--- a/concepts/extending-sails/Hooks/hookspec/routes.md
+++ b/concepts/extending-sails/Hooks/hookspec/routes.md
@@ -5,25 +5,29 @@ The `routes` feature allows a custom hook to easily bind new routes to a Sails a
 ```javascript
 module.exports = function (sails) {
 
-   return {
+    return {
 
-      initialize: function(cb) {
-         this.numRequestsSeen = 0;
-         this.numUnhandledRequestsSeen = 0;
-         return cb();
-      },
-
-      routes: {
-         before: {
-            'GET /*': function (req, res, next) {
-               this.numRequestsSeen++;
-               return next();
-            }
+        initialize: function (cb) {
+            const self = sails.hooks['count-requests'];
+            self.numRequestsSeen = 0;
+            self.numUnhandledRequestsSeen = 0;
+            return cb();
         },
-        after: {
-            'GET /*': function (req, res, next) {
-               this.numUnhandledRequestsSeen++;
-               return next();
+
+        routes: {
+            before: {
+                'GET /*': function (req, res, next) {
+                    const self = sails.hooks['count-requests'];
+                    self.numRequestsSeen++;
+                    return next();
+                }
+            },
+            after: {
+                'GET /*': function (req, res, next) {
+                    const self = sails.hooks['count-requests'];
+                    self.numUnhandledRequestsSeen++;
+                    return next();
+                }
             }
         }
     };


### PR DESCRIPTION
`this` do not point to the hook inside `routes` object's functions (sails 0.12.4), so I changed it to:
`const self = sails.hooks['count-requests'];`

Added missing closing bracket for the `routes`object.
