### PR TITLE
Remove misleading .save description

### DIFF
--- a/reference/waterline/records/save.md
+++ b/reference/waterline/records/save.md
@@ -1,7 +1,7 @@
 # * .save(`callback`)
 
 ### Purpose
-The `save()` method updates your record in the database using the current attributes.  It then returns the newly saved object in the callback.
+The `save()` method updates your record in the database using the current attributes.
 
 ### Overview
 #### Parameters


### PR DESCRIPTION
Starting from version 0.12, .save does not return the newly saved object in the callback.
