### PR TITLE
Add Missing Closing Bracket

### DIFF
--- a/concepts/Custom Responses/AddingCustomResponse.md
+++ b/concepts/Custom Responses/AddingCustomResponse.md
@@ -45,6 +45,7 @@ module.exports = function(message) {
 
     // Otherwise, serve the `views/mySpecialView.*` page
     res.render(viewFilePath);
-  });   
+  });
+}
 ```
 <docmeta name="displayName" value="Adding a Custom Response">


### PR DESCRIPTION
I copied the custom response template and tried to implement it, but noticed an error: 

```
`include-all` attempted to `require(/Users/username/Documents/project/api/responses/unauthorized.js)`, but an error occurred:: 
Details:/Users/username/Documents/project/api/responses/unauthorized.js:45
});
 ^
SyntaxError: Unexpected token )
```

Simply adding a closing bracket solved the problem!