### PR TITLE
Fix for Prepared Statement

### DIFF
--- a/reference/waterline/models/query.md
+++ b/reference/waterline/models/query.md
@@ -12,10 +12,19 @@ Pet.query('SELECT pet.name FROM pet', function(err, results) {
 });
 ```
 
-### Prepared Statement Example
+### Prepared Statement Example for MySQL adapter
 
 ```js
-Pet.query('SELECT pet.name FROM pet WHERE pet.name = ?',[ "dog" ]} ,function(err, results) {
+Pet.query(query: {'SELECT pet.name FROM pet WHERE pet.name = ?', values: [ "dog" ]} ,function(err, results) {
+  if (err) return res.serverError(err);
+  return res.json(results.rows);
+});
+```
+
+### Prepared Statement Example for PostgreSQL adapter
+
+```js
+Pet.query(query: {'SELECT pet.name FROM pet WHERE pet.name = $1', values: [ "dog" ]} ,function(err, results) {
   if (err) return res.serverError(err);
   return res.json(results.rows);
 });

--- a/reference/waterline/models/query.md
+++ b/reference/waterline/models/query.md
@@ -24,7 +24,7 @@ Pet.query(query: {'SELECT pet.name FROM pet WHERE pet.name = ?', values: [ "dog"
 ### Prepared Statement Example for PostgreSQL adapter
 
 ```js
-Pet.query(query: {'SELECT pet.name FROM pet WHERE pet.name = $1', values: [ "dog" ]} ,function(err, results) {
+Pet.query(text: {'SELECT pet.name FROM pet WHERE pet.name = $1', values: [ "dog" ]} ,function(err, results) {
   if (err) return res.serverError(err);
   return res.json(results.rows);
 });


### PR DESCRIPTION
The current documentation is plain wrong, the current one does even have the syntax wrong. The latest commits have been mixing both MySQL and PostgreSQL adapter statments (which differ in the query selector to prepare the statement.