### PR TITLE
Fixing missing commas in file upload parameters

### DIFF
--- a/concepts/File Uploads/uploading-to-amazon-s3.md
+++ b/concepts/File Uploads/uploading-to-amazon-s3.md
@@ -17,8 +17,8 @@ Then use it in one of your controllers:
   uploadFile: function (req, res) {
     req.file('avatar').upload({
       adapter: require('skipper-s3'),
-      key: 'S3 Key'
-      secret: 'S3 Secret'
+      key: 'S3 Key',
+      secret: 'S3 Secret',
       bucket: 'Bucket Name'
     }, function (err, filesUploaded) {
       if (err) return res.negotiate(err);


### PR DESCRIPTION
I've been using this example to integrate Amazon S3 into my file uploads. I noticed some commas were missing from the parameters passed in to the req.file.upload call on L20 and L21.