### PR TITLE
Modify example to fix syntax and a minor bug

### DIFF
--- a/concepts/ORM/Models.md
+++ b/concepts/ORM/Models.md
@@ -89,7 +89,7 @@ findWithSameNameAsPerson: function (opts, cb) {
   // person we're even talking about:
   (function _lookupPersonIfNecessary(afterLookup){
     // (this self-calling function is just for concise-ness)
-    if (typeof person === 'object')) return afterLookup(null, person);
+    if (typeof person === 'object') return afterLookup(null, person);
     Person.findOne(person).exec(afterLookup);
   })(function (err, person){
     if (err) return cb(err);


### PR DESCRIPTION
Based on the code, I think that opts is meant to be a "person" object, so I cleaned up the code to that effect so the examples that call the method with a number, or the object will presumably work correctly.