### PR TITLE
Added sails-generate-views-hbs in the list of generators

### DIFF
--- a/concepts/extending-sails/Generators/generatorList.md
+++ b/concepts/extending-sails/Generators/generatorList.md
@@ -24,6 +24,7 @@
 
 There are over 100 community-supported generators [available on NPM](https://www.npmjs.com/search?q=sails+generate):
 
++ [sails-generate-views-hbs](https://github.com/bhaskarmelkani/sails-generate-views-hbs)
 + [sails-inverse-model](https://github.com/juliandavidmr/sails-inverse-model)
 + [sails-generate-new-gulp](https://github.com/Karnith/sails-generate-new-gulp)
 + [sails-generate-archive](https://github.com/jaumard/sails-generate-archive)


### PR DESCRIPTION
Hi,
I have create a generator for generating handlebars default template.
It works similar to [sails-generate-views-jade](https://github.com/balderdashy/sails-generate-views-jade), but for handlebars.
I have tested and it works completely fine and is very seamless. 