### PR TITLE
Fix variable name from `files` to uploadedFiles

### DIFF
--- a/reference/req/req.file.md
+++ b/reference/req/req.file.md
@@ -41,8 +41,8 @@ In a controller action or policy:
 req.file('avatar').upload(function (err, uploadedFiles){
   if (err) return res.serverError(err);
   return res.json({
-    message: files.length + ' file(s) uploaded successfully!',
-    files: files
+    message: uploadedFiles.length + ' file(s) uploaded successfully!',
+    files: uploadedFiles
   });
 });
 ```


### PR DESCRIPTION
In the example for the `req.file()` documentation, the variable `files` is undefined inside the callback to `upload()`.