### PR TITLE
waterline/models/create.md redundant: remove a closing parentheses

### DIFF
--- a/reference/waterline/models/create.md
+++ b/reference/waterline/models/create.md
@@ -104,7 +104,7 @@ module.exports = {
       }
     });//</Passwords.encryptPassword>
   }//</UserController.signup>
-});
+};
 ```
 
 


### PR DESCRIPTION
removed a closing parentheses.