### PR TITLE
Update req.md - Fixed link

### DIFF
--- a/reference/req/req.md
+++ b/reference/req/req.md
@@ -8,7 +8,7 @@ Sails adds a few methods and properties of its own to the `req` object, like [`r
 
 ### Protocol Support
 
-The chart below describes support for the methods and properties on the Sails [Request](http://sailsjs.com/documentation/reference/req) object (`req`) across multiple transports:
+The chart below describes support for the methods and properties on the Sails [Request](http://sailsjs.com/documentation/reference/request-req) object (`req`) across multiple transports:
 
 <!-- TODO: add SPDY -->
 


### PR DESCRIPTION
The link to the request object (i.e. the link back to this page) was broken, this is the fix