### PR TITLE
updated nanobox hosting docs. added nanobox to faq guides

### DIFF
--- a/concepts/Deployment/Hosting.md
+++ b/concepts/Deployment/Hosting.md
@@ -56,9 +56,11 @@ You can now `git add . && git commit -a -m "your message" && git push` to deploy
 
 ##### Using Nanobox?
 
-+ [Getting Started](https://content.nanobox.io/a-simple-sails-js-example-app/)
-+ [Official Quickstart](https://github.com/nanobox-quickstarts/nanobox-sails)
-+ [Official Guides](https://guides.nanobox.io/nodejs/sails/)
++ [Getting Started: A Simple Sails.js App](https://content.nanobox.io/a-simple-sails-js-example-app/)
++ [Quickstart: nanobox-sails](https://github.com/nanobox-quickstarts/nanobox-sails)
++ [Official Sails.js Guides](https://guides.nanobox.io/nodejs/sails/)
++ [Official Nanobox Docs](https://docs.nanobox.io)
++ [Join Us on Slack for Help](https://slack.nanoapp.io)
 
 ##### Using DigitalOcean?
 

--- a/faq/faq.md
+++ b/faq/faq.md
@@ -102,6 +102,8 @@ Thanks!
 
 
 ##### Articles & blog posts:
++ [Nanobox Blog: Getting Started - A Simple Sails.js App](https://content.nanobox.io/a-simple-sails-js-example-app/)
+<!-- 6-13-2017 -->
 + [Twitter Dev Blog: Guest Post: Twitter Sign-In with Sails.js](https://blog.twitter.com/2015/guest-post-twitter-sign-in-with-treelineio)
 <!-- 3-25-2015 -->
 + [Guest Post on Segment.io Blog: Webhooks with Slack, Segment, and Sails.js/Treeline](https://segment.com/blog/segment-webhooks-slack/)
@@ -216,5 +218,3 @@ The [documentation on the main website](http://sailsjs.com/documentation) is for
 For older releases of Sails that are still widely used, the documentation is compiled from the relevant `sails-docs` branches and hosted on the following subdomains:
 + [0.12.sailsjs.com](http://0.12.sailsjs.com/)
 + [0.11.sailsjs.com](http://0.11.sailsjs.com/)
-
-


### PR DESCRIPTION
This was already merged into master with #875. This is just an update to the nanobox hosting guides, and also adds nanobox to the faq guides section.