### PR TITLE
Update URLs to new EJS locations

### DIFF
--- a/anatomy/views/homepage.ejs.md
+++ b/anatomy/views/homepage.ejs.md
@@ -1,6 +1,6 @@
 # views/homepage.ejs
 ### Purpose
-This is the actual template that is rendered by default when a user visits the base URL of your lifted app.  Notice the file extension?  It stands for [Embedded JavaScript](http://embeddedjs.com/).  EJS is what Sails uses by default to render server side HTML views.  This can be changed in `config/views.js`.
+This is the actual template that is rendered by default when a user visits the base URL of your lifted app.  Notice the file extension?  It stands for [Embedded JavaScript](http://ejs.co/).  EJS is what Sails uses by default to render server side HTML views.  This can be changed in `config/views.js`.
 
 If a new view you've created isn't rendering, make sure you've hooked it up in your `config/routes.js`.
 

--- a/anatomy/views/layout.ejs.md
+++ b/anatomy/views/layout.ejs.md
@@ -1,6 +1,6 @@
 # views/layout.ejs
 ### Purpose
-This [Embedded JavaScript file](http://embeddedjs.com/) acts as the default layout for all server side views rendered by your app.
+This [Embedded JavaScript file](http://ejs.co/) acts as the default layout for all server side views rendered by your app.
 
 Before one of your custom views is sent to the client, it is injected into this file.  It is this file that is actually sent to the client.
 

--- a/concepts/Views/ViewEngines.md
+++ b/concepts/Views/ViewEngines.md
@@ -1,6 +1,6 @@
 # View Engines
 
-The default view engine in Sails is [EJS](https://github.com/visionmedia/ejs).
+The default view engine in Sails is [EJS](https://github.com/mde/ejs).
 
 ##### Swapping out the view engine
 
@@ -16,7 +16,7 @@ For example, to switch to jade, run `npm install jade --save-dev`, then set `eng
   - [dust](https://github.com/akdubya/dustjs) [(website)](http://akdubya.github.com/dustjs/) (.dust)
   - [eco](https://github.com/sstephenson/eco)
   - [ect](https://github.com/baryshev/ect) [(website)](http://ectjs.com/)
-  - [ejs](https://github.com/visionmedia/ejs) (.ejs)
+  - [ejs](https://github.com/mde/ejs) (.ejs)
   - [haml](https://github.com/visionmedia/haml.js) [(website)](http://haml.info/)
   - [haml-coffee](https://github.com/9elements/haml-coffee) [(website)](http://haml.info/)
   - [handlebars](https://github.com/wycats/handlebars.js/) [(website)](http://handlebarsjs.com/) (.hbs)

--- a/concepts/Views/Views.md
+++ b/concepts/Views/Views.md
@@ -8,7 +8,7 @@ Alternatively, a view can be compiled directly into an HTML string for use in yo
 
 ##### Creating a view
 
-By default, Sails is configured to use EJS ([Embedded Javascript](http://embeddedjs.com/)) as its view engine.  The syntax for EJS is highly conventional- if you've worked with php, asp, erb, gsp, jsp, etc., you'll immediately know what you're doing.
+By default, Sails is configured to use EJS ([Embedded Javascript](http://ejs.co/)) as its view engine.  The syntax for EJS is highly conventional- if you've worked with php, asp, erb, gsp, jsp, etc., you'll immediately know what you're doing.
 
 If you prefer to use a different view engine, there are a multitude of options.  Sails supports all of the view engines compatible with [Express](https://github.com/balderdashy/sails-docs/blob/master/PAGE_NEEDED.md) via [Consolidate](https://github.com/visionmedia/consolidate.js/).
 


### PR DESCRIPTION
This includes the new website (the old one is heavily broken and no longer relevant as it only applies to v1) and new code repository (which apparently changed on account of EJS v2).