### PR TITLE
"US Standard" is not the name of the region anymore

### DIFF
--- a/concepts/File Uploads/uploading-to-amazon-s3.md
+++ b/concepts/File Uploads/uploading-to-amazon-s3.md
@@ -1,6 +1,6 @@
 # Uploading to Amazon S3
 
->Please note that your Amazon S3 bucket must be created in the 'US Standard' region. 
+>Please note that your Amazon S3 bucket must be created in the 'US Standard' region - recently renamed by AWS to US East (N. Virginia). 
 >If you fail to do so, you will get a 'TypeError('Uncaught, unspecified "error" event.').
 
 With Sails, you can stream file uploads to Amazon S3 with very little additional configuration.


### PR DESCRIPTION
Official AWS S3 docs (http://docs.aws.amazon.com/general/latest/gr/rande.html) says:
> Amazon S3 renamed the US Standard Region to the US East (N. Virginia) Region to be consistent with AWS regional naming conventions.