### PR TITLE
Update res.redirect.md

### DIFF
--- a/reference/res/res.redirect.md
+++ b/reference/res/res.redirect.md
@@ -4,20 +4,16 @@ Redirect the requesting user-agent to the given absolute or relative url.
 
 
 ### Usage
-```usage
-return res.redirect(url);
+```js
+return res.redirect([status,] url);
 ```
-
-
-_Or:_
-+ `return res.redirect(statusCode, url);`
 
 ### Arguments
 
 |   | Argument       | Type        | Details |
 |---|----------------|:-----------:|---------|
-| 1 | _statusCode_   | ((number?)) | An optional status code (e.g. 301).  (If omitted, a status code of 302 will be assumed.)
-| 2 | url            | ((string))  | A URL expression (see below for complete specification).<br/> e.g. `"http://google.com"` or `"/login"`
+| 1 | `status`       | ((integer)) |  (optional) a positive integer that corresponds to an [HTTP status code](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html).  Defaults to 302 ("found").|
+| 2 | `url`          | ((string))  | A URL expression (see below for complete specification).<br/> e.g. `"http://google.com"` or `"/login"`
 
 
 
@@ -45,6 +41,12 @@ The final special-case is a back redirect, which allows you to redirect a reques
 ```javascript
 return res.redirect('back');
 ```
+
+If you want to send a custom status code along with a redirect, you can do so by sending the status as the first argument to res.redirect:
+```javascript
+return res.redirect(301, '/foo');
+```
+
 
 ### Notes
 > + This method is **terminal**, meaning it is generally the last line of code your app should run for a given request (hence the advisory usage of `return` throughout these docs).


### PR DESCRIPTION
chaining status() and redirect() does not work, I believe the redirect defaults to 302 and overwrites whatever status is set in the status() part of the chain. Switching to the method documented in express works. This document will now match closer to what express has documented . https://expressjs.com/en/4x/api.html#res.redirect

copy of PR #849 , resubmitting for v1.0 branch