### PR TITLE
Fixed command showing as regular text

### DIFF
--- a/anatomy/api/models/User.js.md
+++ b/anatomy/api/models/User.js.md
@@ -1,6 +1,6 @@
 # api/models/User.js
 ### Purpose
-This file was created when you ran 'sails generate api User'.  It contains the structure for the model called 'User'.
+This file was created when you ran `sails generate api User`.  It contains the structure for the model called 'User'.
 
 In this file you will specify what attributes each model instance (record) should have.  You can also add custom model instance methods, as well as override the global settings for things like `policies` and `connections`.
 


### PR DESCRIPTION
Normal quotes were used instead of backticks surrounding a command. Therefore MarkDown rendered this as regular text instead of a command.