### PR TITLE
Update Querylanguage.md

### DIFF
--- a/concepts/ORM/Querylanguage.md
+++ b/concepts/ORM/Querylanguage.md
@@ -286,7 +286,7 @@ Model.find().paginate({page: 2, limit: 10});
 > **Waterline**
 >
 > You can find out more about the Waterline API below:
-> * [Sails.js Documentation](http://sailsjs.com/documentation/reference/waterline/queries)
+> * [Sails.js Documentation](http://sailsjs.com/documentation/reference/waterline-orm/queries)
 > * [Waterline README](https://github.com/balderdashy/waterline/blob/master/README.md)
 > * [Waterline Reference Docs](http://sailsjs.com/documentation/reference/waterline-orm)
 > * [Waterline Github Repository](https://github.com/balderdashy/waterline)


### PR DESCRIPTION
Link to Sails.js Documentation on Working with Queries was missing "-orm" between "/waterline" and "/queries"