### PR TITLE
Model ORM. autoCreatedAt, autoUpdatedAt, autoIncrement, columnType and unique should be in autoMigrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/concepts/ORM/Attributes.md
+++ b/concepts/ORM/Attributes.md
@@ -160,7 +160,7 @@ module.exports = {
     },
     email: {
       type: 'string',
-      unique: true
+      autoMigrations: { unique:true },
     }
   }
 };
@@ -201,7 +201,7 @@ module.exports = {
   attributes: {
     id: {
       type: 'number',
-      unique: true,
+      autoMigrations: { unique:true },
       columnName: 'the_primary_key'
     },
     name: {
@@ -214,7 +214,7 @@ module.exports = {
     },
     email: {
       type: 'string',
-      unique: true,
+      autoMigrations: { unique:true },
       columnName: 'email_address'
     }
   }
@@ -258,7 +258,7 @@ Indicates the type of physical-level column data type to use for an attribute wh
 attributes: {
   placeInLine: {
     type: 'number',
-    columnType: 'float'
+    autoMigrations: { columnType:'FLOAT' }
   }
 }
 ```
@@ -276,7 +276,7 @@ Sets up the attribute as an auto-increment key.  When a new record is added to t
 attributes: {
   placeInLine: {
     type: 'number',
-    autoIncrement: true
+    autoMigrations: { autoIncrement: true }
   }
 }
 ```
@@ -289,7 +289,7 @@ Ensures no two records will be allowed with the same value for the target attrib
 attributes: {
   username: {
     type: 'string',
-    unique: true
+    autoMigrations: { unique:true },
   }
 }
 ```

--- a/concepts/ORM/Models.md
+++ b/concepts/ORM/Models.md
@@ -12,7 +12,7 @@ module.exports = {
   attributes: {
     nameOnMenu: { type: 'string', required: true },
     price: { type: 'string', required: true },
-    percentRealMeat: { type: 'number', defaultsTo: 20, columnType: 'FLOAT' },
+    percentRealMeat: { type: 'number', defaultsTo: 20, autoMigrations: { columnType: 'FLOAT' }},
     numCalories: { type: 'number' },
   },
 };

--- a/concepts/ORM/Models.md
+++ b/concepts/ORM/Models.md
@@ -12,7 +12,10 @@ module.exports = {
   attributes: {
     nameOnMenu: { type: 'string', required: true },
     price: { type: 'string', required: true },
-    percentRealMeat: { type: 'number', defaultsTo: 20, autoMigrations: { columnType: 'FLOAT' }},
+    percentRealMeat: { 
+      type: 'number', 
+      defaultsTo: 20, 
+      autoMigrations: { columnType: 'FLOAT' }},
     numCalories: { type: 'number' },
   },
 };

--- a/concepts/ORM/model-settings.md
+++ b/concepts/ORM/model-settings.md
@@ -55,9 +55,15 @@ Most of the time, you'll define attributes in your individual model definitions 
 
 ```js
 attributes: {
-  id: { type: 'number', autoMigrations: {autoIncrement: true }},
-  createdAt: { type: 'number', autoMigrations: { autoCreatedAt: true }},
-  updatedAt: { type: 'number', autoMigrations: { autoUpdatedAt: true }},
+  id: { 
+    type: 'number', 
+    autoMigrations: {autoIncrement: true }},
+  createdAt: { 
+    type: 'number', 
+    autoMigrations: { autoCreatedAt: true }},
+  updatedAt: { 
+    type: 'number', 
+    autoMigrations: { autoUpdatedAt: true }},
 }
 ```
 

--- a/concepts/ORM/model-settings.md
+++ b/concepts/ORM/model-settings.md
@@ -55,9 +55,9 @@ Most of the time, you'll define attributes in your individual model definitions 
 
 ```js
 attributes: {
-  id: { type: 'number', autoIncrement: true },
-  createdAt: { type: 'number', autoCreatedAt: true },
-  updatedAt: { type: 'number', autoUpdatedAt: true },
+  id: { type: 'number', autoMigrations: {autoIncrement: true }},
+  createdAt: { type: 'number', autoMigrations: { autoCreatedAt: true }},
+  updatedAt: { type: 'number', autoMigrations: { autoUpdatedAt: true }},
 }
 ```
 

--- a/upgrading/To1.0.md
+++ b/upgrading/To1.0.md
@@ -158,20 +158,30 @@ Remove any `autoPK`, `autoCreatedAt` and `autoUpdatedAt` properties from your mo
 
 ```javascript
   attributes: {
-    createdAt: { type: 'number', autoCreatedAt: true, },
-    updatedAt: { type: 'number', autoUpdatedAt: true, },
-    id: { type: 'number', autoIncrement: true}, // <-- for SQL databases
+    createdAt: { type: 'number', autoMigrations: {autoCreatedAt: true }},
+    updatedAt: { type: 'number', autoMigrations: {autoUpdatedAt: true }},
+    id: { type: 'number', autoMigrations: {autoIncrement: true}}, // <-- for SQL databases
     id: { type: 'string', columnName: '_id'}, // <-- for MongoDB
   }
 ```
 
+##### The `columnType` has been added and is a property of `autoMigrations`
+To allow for flexibility in automigrations, attributes may also specify a new key, columnType. If specified, the columnType is sent to the appropriate adapter during automigration (in sails-hook-orm). This allows Sails/Waterline models to indicate how the values for individual attributes should be stored at rest vs. how they are validated/coerced when your code calls .create() or .update().
+
+```javascript
+  attributes: {
+    date: { 
+      type: 'string', 
+      autoMigrations: {autoCreatedAt: true, columnType: 'DATETIME' }}
+  }
+```
 ##### The `autoPK` top-level property is no longer supported
 
 This property was formerly used to indicate whether or not Waterline should create an `id` attribute as the primary key for a model.  Starting with Sails v1.0 / Waterline 0.13, Waterline will no longer create any attributes in the background.  Instead, the `id` attribute must be defined explicitly.  There is also a new top-level model property called `primaryKey`, which can be set to the name of the attribute that should be used as the model's primary key.  This value defaults to `id` for every model, so in general you won't have to set it yourself.
 
-##### The `autoUpdatedAt` and `autoCreatedAt` model settings are now attribute-level properties
+##### The `autoUpdatedAt` and `autoCreatedAt` model settings are now `autoMigrations` properties
 
-These properties were formerly used to indicate whether or not Waterline should create `createdAt` and `updatedAt` timestamps for a model.  Starting with Sails v1.0 / Waterline 0.13, Waterline will no longer create these attributes in the background.  Instead, the `createdAt` and `updatedAt` attributes must be defined explicitly if you want to use them.  By adding `autoCreatedAt: true` or `autoUpdatedAt: true` to an attribute definition, you can instruct Waterline to set that attribute to the current timestamp whenever a record is created or updated. Depending on the type of these attributes, the timestamps will be generated in one of two formats:
+These properties were formerly used to indicate whether or not Waterline should create `createdAt` and `updatedAt` timestamps for a model.  Starting with Sails v1.0 / Waterline 0.13, Waterline will no longer create these attributes in the background.  Instead, the `createdAt` and `updatedAt` attributes must be defined explicitly if you want to use them.  By adding `autoMigrations: {autoCreatedAt: true}` or `autoMigrations: {autoUpdatedAt: true}` to an attribute definition, you can instruct Waterline to set that attribute to the current timestamp whenever a record is created or updated. Depending on the type of these attributes, the timestamps will be generated in one of two formats:
   + For `type: 'string'`, these timestamps are stored in the same way as they were in Sails 0.12: as timezone-agnostic ISO 8601 JSON timestamp strings (e.g. `'2017-12-30T12:51:10Z'`).  So if any of your front-end code is relying on the timestamps as strings it's important to set this to `string`.
   + For `type: 'number'`, these timestamps are stored as JS timestamps (the number of milliseconds since Jan 1, 1970 at midnight UTC).
 


### PR DESCRIPTION
The documentation at:
https://next.sailsjs.com/documentation/concepts/models-and-orm/attributes
https://next.sailsjs.com/documentation/concepts/models-and-orm/model-settings
https://next.sailsjs.com/documentation/concepts/models-and-orm/models
https://github.com/balderdashy/sails-docs/blob/1.0/upgrading/To1.0.md

show that autoCreatedAt, autoUpdatedAt, autoIncrement, columnType and unique as first order attribute parameters instead of under the autoMigrations. 

e.g.
```
module.exports = {
  attributes: {
    email: {
      type: 'string',
      unique:true ,
    }
  }
};
```
Should be
```
module.exports = {
  attributes: {
    email: {
      type: 'string',
      autoMigrations: { unique:true },
    }
  }
};
```
I have corrected this.

Cheers
/Mikael