### PR TITLE
Fix event documentation for `lower`

### DIFF
--- a/reference/application/advanced-usage/sails.lower.md
+++ b/reference/application/advanced-usage/sails.lower.md
@@ -36,7 +36,7 @@ sailsApp.lower(
 ```
 
 ### Notes
-> + After an app is successfully lowered, it will emit the `lowered` event.
+> + The app will emit the `lower` event before shutting down the HTTP and WebSocket services.
 > + Lowered apps cannot be lifted again.
 
 <docmeta name="displayName" value="sails.lower()">


### PR DESCRIPTION
* Remove note about `lowered` event being sent as there is no such event.
* Add note about `lower` event being sent *before* shutting down HTTP/WebSocket services.