### PR TITLE
Update sailsdebug.md

### DIFF
--- a/reference/cli/sailsdebug.md
+++ b/reference/cli/sailsdebug.md
@@ -39,16 +39,10 @@ To debug your Sails app using node-inspector, first install it over npm
 $ npm install -g node-inspector
 ```
 
-Then, launch it with the `node-inspector` command
-
-```bash
-$ node-inspector
-```
-
 Now, you can lift your Sails app in debug mode
 
 ```bash
-$ sails debug
+$ sails inspect
 ```
 
 Once the application is launched, visit http://127.0.0.1:8080?port=5858 in Opera or Chrome (_sorry, other browsers!_). Now you can request your app as usual on port 1337 and debug your code from the browser.


### PR DESCRIPTION
node-inspector will throw the following error.
```bash
node-inspector
module.js:540
    throw err;
    ^

Error: Cannot find module '_debugger'
    at Function.Module._resolveFilename (module.js:538:15)
    at Function.Module._load (module.js:468:25)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/node-inspector/lib/debugger.js:2:16)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
```

sails debug is deprecated and have to run sails inspect instead
```bash
 info: Running app in debug mode...
 info: ( to exit, type <CTRL>+<C> )

(node:6714) [DEP0062] DeprecationWarning: `node --debug` and `node --debug-brk` are invalid. Please use `node --inspect` or `node --inspect-brk` instead.
```