### PR TITLE
customToJSON does not support async functions

### DIFF
--- a/concepts/ORM/model-settings.md
+++ b/concepts/ORM/model-settings.md
@@ -86,6 +86,8 @@ customToJSON: function() {
 }
 ```
 
+Currently the customToJSON function does not support async capabilities. This allows synchronous bits in core to stay synchronous and provide better stability to the system as a whole.
+
 > Note that the `this` variable available in `customToJSON` is a _direct reference to the actual record object_, so be careful not to modify it.  In other words, avoid writing code like `delete this.password`.  Instead, use methods like `_.omit()` or `_.pick()` to get a _copy_ of the record.  Or just construct a new dictionary and return that (e.g. `return { foo: this.foo }`).
 
 ### tableName


### PR DESCRIPTION
This issue was brought up in the sails gitter channel on may 30th. Mike asked if someone could add this note.