### PR TITLE
Fix typo

### DIFF
--- a/reference/waterline/models/models.md
+++ b/reference/waterline/models/models.md
@@ -18,7 +18,7 @@ Most built-in model methods accept a callback as an optional final argument. If 
  --------------------- | ------------------------------------------------------------------------
  `.create()`           | Create record consisting of object passed in
  `.find()`             | Lookup an array of records which match the specified criteria
- `.findOne()`          | Lookup a single record which matches the specified criteria, or send back `null` if it doesn't.
+ `.findOne()`          | Lookup a single record which matches the specified criteria, or send back `undefined` if it doesn't.
  `.update()`           | Update records matching the specified criteria, setting the specified object of `attrName:value` pairs.
  `.destroy()`          | Destroy records matching the specified criteria.
  `.findOrCreate()`     | Lookup a single record which matches the specified criteria, or create it if it doesn't.


### PR DESCRIPTION
According to [docs](https://sailsjs.com/documentation/reference/waterline-orm/models/find-one) `findOne` return `undefined`