### PR TITLE
Update sails.config.i18n.md: specificity

### DIFF
--- a/reference/sails.config/sails.config.i18n.md
+++ b/reference/sails.config/sails.config.i18n.md
@@ -8,7 +8,7 @@ Configuration for Sails' built-in internationalization & localization features. 
 
 | Property           | Type        | Default               | Details |
 |:-------------------|:-----------:|:----------------------|:--------|
-| `locales`          | ((array))   | `['en','es','fr','de']` | List of supported [locale codes](http://en.wikipedia.org/wiki/BCP_47)
+| `locales`          | ((array))   | `['en','es','fr','de']` | List of supported [locale codes](http://en.wikipedia.org/wiki/BCP_47). Note that these values and the name of their corresponding translation files must be lowercase.
 | `localesDirectory` | ((string))  | `'config/locales'`     | The app-relative path to the folder containing your locale translations (i.e. stringfiles).  Alternatively, an absolute path maybe provided.
 | `defaultLocale`    | ((string))  | `'en'`                  | The default locale for the site. Note that this setting will be overridden for any request that sends an "Accept-Language" header (i.e. most browsers), but it's still useful if you need to localize the response for requests made by non-browser clients (e.g. mobile devices, IoT, cURL, Postman, etc.).
 


### PR DESCRIPTION
Should specify locales & their translation files must be lowercase. 

Expected a case-insensitive match on browsers sending `Accept-Language` headers with a region (ie, `zh-TW` for Chinese as used in Taiwan vs. `zh` for 'any old' Chinese), and after much head-banging realised this isn't the case as the browsers headers are lowercased somewhere along the way.