### PR TITLE
In Sails v1.0, the `!` modifier is deprecated.

### DIFF
--- a/concepts/ORM/Querylanguage.md
+++ b/concepts/ORM/Querylanguage.md
@@ -71,13 +71,13 @@ var waltersAndSkylers = await Model.find({
 
 #### Not-In Modifier
 
-Provide an array wrapped in a dictionary under a `!` key (like `{ '!': [...] }`) to find records whose value for this attribute _ARE NOT_ exact matches for any of the specified search terms.
+Provide an array wrapped in a dictionary under a `!=` key (like `{ '!=': [...] }`) to find records whose value for this attribute _ARE NOT_ exact matches for any of the specified search terms.
 
 > This is more or less equivalent to "NOT IN" queries in SQL, and the `$nin` operator in MongoDB.
 
 ```javascript
 var everyoneExceptWaltersAndSkylers = await Model.find({
-  name: { '!' : ['walter', 'skyler'] }
+  name: { '!=' : ['walter', 'skyler'] }
 });
 ```
 


### PR DESCRIPTION
### Not-In Modifier
The `where` clause of this query contains
a `!` modifier (for `name`).  But as of Sails v1.0,
this modifier is deprecated.  (Please use `!=` instead.)
> This backwards compatibility may be removed
> in a future release of Sails/Waterline.  If this usage
> is left unchanged, then queries like this one may eventually
> fail with an error.