### PR TITLE
Fix attribute names in through model

### DIFF
--- a/concepts/ORM/Associations/ThroughAssociations.md
+++ b/concepts/ORM/Associations/ThroughAssociations.md
@@ -48,10 +48,10 @@ module.exports = {
 // myApp/api/models/PetUser.js
 module.exports = {
   attributes: {
-    owner:{
+    owners:{
       model:'user'
     },
-    pet: {
+    pets: {
       model: 'pet'
     }
   }


### PR DESCRIPTION
I think there's a bug in the docs, I'm not sure. But for the through association example - https://sailsjs.com/documentation/concepts/models-and-orm/associations/through-associations

The "through model" it has keys of `pet` (singular) and `owner` (singular). However `models/User.js` has `pets` (plural), and `models/Pet.js` has `owners` (plural). This causes ORM startup problem.

I encountered this error when using mongo.