### PR TITLE
beforeCreate is supported by createEach

### DIFF
--- a/concepts/ORM/Lifecyclecallbacks.md
+++ b/concepts/ORM/Lifecyclecallbacks.md
@@ -13,8 +13,6 @@ The `afterCreate` lifecycle callback will only be run on queries that have the `
   - beforeCreate: fn(recordToCreate, proceed)
   - afterCreate: fn(newlyCreatedRecord, proceed)
 
-> `beforeCreate()` is not run on bulk inserts of data using `createEach`.
-
 ##### Lifecycle callbacks on `.update()`
 
 The `afterUpdate` lifecycle callback will only be run on `.update()` queries that have the `fetch` meta flag set to `true`. For more information on using the `meta` flags, see [Waterline Queries](https://sailsjs.com/documentation/reference/waterline-orm/queries/meta).


### PR DESCRIPTION
LC hooks have been implemented for createEach bulk inserts. See https://github.com/balderdashy/waterline/commit/dda4dd703ade7f2ce28c652fa6be9e297ffc0760.