### PR TITLE
[patch] Fix broken link in concept/ORM/model-settings.md

### DIFF
--- a/concepts/ORM/model-settings.md
+++ b/concepts/ORM/model-settings.md
@@ -120,7 +120,7 @@ await User.find();
 // => SELECT * FROM foo_bar;
 ```
 
-> What's in a `tableName`?  In databases like MySQL and PostgreSQL, the setting refers to a literal "table".  In MongoDB, it refers to a "collection".  It's really just about familiarity: That which we call a "table", by any other word would query as swell.
+> What's in a `tableName`?  In databases like MySQL and PostgreSQL, the setting refers to a literal "table".  In MongoDB, it refers to a "collection".  It's really just about familiarity: That which we call a "table", by any other word would query as well.
 
 
 

--- a/concepts/ORM/model-settings.md
+++ b/concepts/ORM/model-settings.md
@@ -120,7 +120,7 @@ await User.find();
 // => SELECT * FROM foo_bar;
 ```
 
-> What's in a `tableName`?  In databases like MySQL and PostgreSQL, the setting refers to a literal "table".  In MongoDB, it refers to a "collection".  It's really just about familiarity: That which we call a "table", by any other word would query as swell. 
+> What's in a `tableName`?  In databases like MySQL and PostgreSQL, the setting refers to a literal "table".  In MongoDB, it refers to a "collection".  It's really just about familiarity: That which we call a "table", by any other word would query as swell.
 
 
 
@@ -204,7 +204,7 @@ The `schema` setting allows you to toggle a model between "schemaless" or "schem
 
 ### datastore
 
-The name of the [datastore configuration](https://sailsjs.com/documentation/reference/sails-config/sails-config-datastores) that a model will use to find records, create records, etc.
+The name of the [datastore configuration](https://sailsjs.com/documentation/reference/configuration/sails-config-datastores) that a model will use to find records, create records, etc.
 
 ```
 datastore: 'legacyECommerceDb'
@@ -216,7 +216,7 @@ datastore: 'legacyECommerceDb'
 
 This allows you to indicate the database where this model will fetch and save its data.  Unless otherwise specified, every model in your app uses a built-in datastore named "default", which is included in every new Sails app out of the box.  This makes it easy to configure your app's primary database while still allowing you to override the `datastore` setting for any particular model.
 
-For more about configuring your app's datastores, see [Reference > Configuration > Datastores](https://sailsjs.com/documentation/reference/sails-config/sails-config-datastores).
+For more about configuring your app's datastores, see [Reference > Configuration > Datastores](https://sailsjs.com/documentation/reference/configuration/sails-config-datastores).
 
 
 ### dataEncryptionKeys


### PR DESCRIPTION
#### What Does This PR Do?
This PR fixes the broken link to datastore configuration on the model settings page

#### Screenshot(s)
- The two links on this screenshot below lead to 404 page
![Screen Shot 2019-05-07 at 8 39 32 PM](https://user-images.githubusercontent.com/17351527/57328102-68984f00-7108-11e9-8c23-c11ab5d21f36.png)

