### PR TITLE
Added afterDestroy lifecycle example

### DIFF
--- a/concepts/ORM/Lifecyclecallbacks.md
+++ b/concepts/ORM/Lifecyclecallbacks.md
@@ -66,5 +66,60 @@ module.exports = {
 };
 ```
 
+If you want to delete child objects after deleting its parent, you can use the `afterDestroy` lifecycle callback. Be careful when using this, as you may lose sensitive data! In this example we will have 2 Models. `Invoice` and `Item`. `Invoice` to `Item` corresponds to `One-to-many` association relation. See [One-to-many associations](https://sailsjs.com/documentation/concepts/models-and-orm/associations/one-to-many).
+
+```javascript
+// Invoice.js
+
+module.exports = {
+  attributes: {
+    client_name: { type: 'string', required: true },
+    client_email: { type: 'string', required: false },
+    project_name: { type: 'string', required: true },
+    project_description: { type: 'string', required: false },
+    invoice_status: { type: 'string', defaultsTo: 'unpaid' },
+    due_date: { type: 'string', required: false },
+    total_price: { type: 'number', required: true},
+    items: {
+      collection: 'item',
+      via: 'invoice'
+    },
+    user: {
+      model: 'user'
+    }
+  },
+
+  async beforeDestroy(criteria, proceed) {
+    try {
+      // destroy items related to parent
+      // we can access the deleted parent object using 
+      // criteria object
+      await Item.destroy({invoice: criteria.where.id});      
+    } catch (error) {
+      return proceed(error);
+    }
+    return proceed();
+  }
+
+};
+
+
+// Item.js
+
+module.exports = {
+
+  attributes: {
+    name: { type: 'string', required: true },
+    price: { type: 'number', columnType: 'float', required: false },
+    invoice: {
+      model: 'invoice'
+    }
+  },
+};
+
+
+
+```
+
 
 <docmeta name="displayName" value="Lifecycle callbacks">


### PR DESCRIPTION
I was looking for a way to cascade delete my objects. I found out that using `afterDestroy` did the trick. It wasn't in the docs, so I hope by adding it, it would benefit others.