### PR TITLE
[misc] minor change to sailslift.md, and a question

### DIFF
--- a/reference/cli/sailslift.md
+++ b/reference/cli/sailslift.md
@@ -1,7 +1,7 @@
-# sails lift
+# Sails lift
 
 
-Run the Sails app in the current dir (if `node_modules/sails` exists, it will be used instead of the globally installed Sails)
+Run the Sails app in the current dir (if `node_modules/sails` exists, it will be used instead of the globally installed Sails).
 
 ```usage
 sails lift

--- a/reference/cli/sailslift.md
+++ b/reference/cli/sailslift.md
@@ -1,4 +1,4 @@
-# Sails lift
+# `sails lift`
 
 
 Run the Sails app in the current dir (if `node_modules/sails` exists, it will be used instead of the globally installed Sails).


### PR DESCRIPTION
Capitalized the first word in the title. 
I would guess that Sails is lowercase in the title because it refers to a command-line command. I've been formatting it in sentence case in my updates, but we could instead use the ticks to format the title as a command and leave everything lowercase. Let me know if that would be better, and I can go back in and reformat the titles within the Command-line interface section.