### PR TITLE
[misc] changes to res.cookie.md

### DIFF
--- a/reference/res/res.cookie.md
+++ b/reference/res/res.cookie.md
@@ -13,10 +13,10 @@ res.cookie(name, value [,options]);
 
 The `path` option defaults to "/".
 
-`maxAge` is a convenience option for setting `expires` relative to the current time in milliseconds. 
+`maxAge` is a convenience option that sets `expires` relative to the current time in milliseconds. 
 
 ```javascript
-res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true })
+res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true });
 ```
 
 An object that is passed is then serialized as JSON, which is automatically parsed by the Express body-parser middleware.

--- a/reference/res/res.cookie.md
+++ b/reference/res/res.cookie.md
@@ -1,4 +1,4 @@
-# res.cookie()
+# `res.cookie()`
 
 Sets a cookie with name (`name`) and value (`value`) to be sent along with the response.
 
@@ -11,22 +11,22 @@ res.cookie(name, value [,options]);
 
 ### Details
 
-The "path" option defaults to "/".
+The `path` option defaults to "/".
 
-The "maxAge" option is a convenience option for setting "expires" relative to the current time in milliseconds. The following is equivalent to the previous example.
+`maxAge` is a convenience option for setting `expires` relative to the current time in milliseconds. 
 
 ```javascript
 res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true })
 ```
 
-An object may be passed which is then serialized as JSON, which is automatically parsed by the bodyParser() middleware.
+An object that is passed is then serialized as JSON, which is automatically parsed by the Express body-parser middleware.
 
 ```javascript
 res.cookie('cart', { items: [1,2,3] });
 res.cookie('cart', { items: [1,2,3] }, { maxAge: 900000 });
 ```
 
-Signed cookies are also supported through this method. Simply pass the signed option. When given res.cookie() will use the secret passed to express.cookieParser(secret) to sign the value.
+Signed cookies are also supported through this method&mdash;just pass the `signed` option, set to `true`. `res.cookie()` will then use the secret passed into `express.cookieParser(secret)` to sign the value.
 
 ```javascript
 res.cookie('name', 'tobi', { signed: true });


### PR DESCRIPTION
Ticks added to title.
In Details, removed the reference to "the previous example", which doesn't seem to exist. 
It seems like a lot of the terms in double quotes should be in ticks, based on how I've seen them (double quotes and ticks) used in the docs thus far.
I think that bodyParser() middleware is referring to the Express body-parsing middleware, so I made that explicit. 
Reworded a couple of things for clarity and flow.