### PR TITLE
[misc] Fixed the `populate` method references

### DIFF
--- a/concepts/ORM/Associations/ManytoMany.md
+++ b/concepts/ORM/Associations/ManytoMany.md
@@ -86,7 +86,7 @@ await Pet.removeFromCollection(300, 'owners', [10, 12]);
 
 Note that adding or removing associated records from one side of a many-to-many relationship will automatically affect the other side.  For example, adding records to the `pets` attribute of a `User` model record with `.addToCollection()` will immediately affect the `owners` attributes of the linked `Pet` records.
 
-To return associated collections along with a record retrieved by [`.find()`](https://sailsjs.com/documentation/reference/waterline-orm/models/find) or [`.findOne()`](https://sailsjs.com/documentation/reference/waterline-orm/models/find-one), use the [`.populate()`](https://sailsjs.com/documentation/reference/waterline-orm/query/populate) method.
+To return associated collections along with a record retrieved by [`.find()`](https://sailsjs.com/documentation/reference/waterline-orm/models/find) or [`.findOne()`](https://sailsjs.com/documentation/reference/waterline-orm/models/find-one), use the [`.populate()`](https://sailsjs.com/documentation/reference/waterline-orm/queries/populate) method.
 
 ### Dominance
 

--- a/concepts/ORM/Associations/OneWayAssociation.md
+++ b/concepts/ORM/Associations/OneWayAssociation.md
@@ -4,7 +4,7 @@
 
 ### Overview
 
-A one way association is where a model is associated with another model.  You could query that model and [populate](https://sailsjs.com/documentation/reference/waterline-orm/query/populate) to get the associated model.  You can't however query the associated model and populate to get the associating model.
+A one way association is where a model is associated with another model.  You could query that model and [populate](https://sailsjs.com/documentation/reference/waterline-orm/queries/populate) to get the associated model.  You can't however query the associated model and populate to get the associating model.
 
 ### One Way Example
 
@@ -41,7 +41,7 @@ module.exports = {
 }
 ```
 
-Now that the association is setup, you can [populate](https://sailsjs.com/documentation/reference/waterline-orm/query/populate) the pony association.
+Now that the association is setup, you can [populate](https://sailsjs.com/documentation/reference/waterline-orm/queries/populate) the pony association.
 
 ```javascript
 var usersWithPonies = await User.find({ name:'Mike' }).populate('pony');

--- a/concepts/ORM/Associations/OnetoMany.md
+++ b/concepts/ORM/Associations/OnetoMany.md
@@ -70,7 +70,7 @@ await Pet.create({
 ```
 
 Now that the `Pet` is associated with the `User`, all the pets belonging to a specific user can
-be populated by using the [`.populate()`](https://sailsjs.com/documentation/reference/waterline-orm/query/populate) method.
+be populated by using the [`.populate()`](https://sailsjs.com/documentation/reference/waterline-orm/queries/populate) method.
 
 ```javascript
 var users = await User.find().populate('pets');

--- a/concepts/ORM/Associations/ThroughAssociations.md
+++ b/concepts/ORM/Associations/ThroughAssociations.md
@@ -57,7 +57,7 @@ module.exports = {
 }
 ```
 
-By using the `PetUser` model, we can use [`.populate()`](https://sailsjs.com/documentation/reference/waterline-orm/query/populate) on both the `User` model and `Pet` model just as we do in a normal [many-to-many](https://sailsjs.com/documentation/concepts/models-and-orm/associations/many-to-many) association.
+By using the `PetUser` model, we can use [`.populate()`](https://sailsjs.com/documentation/reference/waterline-orm/queries/populate) on both the `User` model and `Pet` model just as we do in a normal [many-to-many](https://sailsjs.com/documentation/concepts/models-and-orm/associations/many-to-many) association.
 
 > Currently, if you would like to add additional information to the `through` table, it will not be available when calling `.populate`. To do this you will need to query the `through` model manually.
 


### PR DESCRIPTION
Before, all references pointed to a [non-existent page](https://sailsjs.com/documentation/reference/waterline-orm/query/populate), giving a 404 error to the user.

The [docs for this exist](https://sailsjs.com/documentation/reference/waterline-orm/queries/populate) and its URL was a little different from the one that was pointed.

I just fixed it :smiley: 