### PR TITLE
Note that status not respected by res.redirect()

### DIFF
--- a/reference/res/res.status.md
+++ b/reference/res/res.status.md
@@ -16,6 +16,7 @@ res.send('I am a teapot');
 ### Notes
 >+ The status code may be set up until the response is sent.
 >+ `res.status()` is effectively just a chainable alias of Node's `res.statusCode = …;`.
+>+ As of Sails v1.x, for HTTP requests, `res.redirect()` [does not respect the status code established by `res.status()`](https://github.com/balderdashy/sails-docs/pull/796#issuecomment-284224746).
 
 
 


### PR DESCRIPTION
Like the title says, `res.redirect()` doesn't respect the status code set by `res.status()`. There's language to this effect on the `res.redirect()` page, but it should probably be here, too.