### PR TITLE
Add UsageError example for `parseBlueprintOptions`

### DIFF
--- a/reference/sails.config/sails.config.blueprints.md
+++ b/reference/sails.config/sails.config.blueprints.md
@@ -46,6 +46,11 @@ parseBlueprintOptions: function(req) {
     if (queryOptions.criteria.limit > 100) {
       queryOptions.criteria.limit = 100;
     }
+    // NOTE: example, check about will prevent this error
+    if (queryOptions.criteria.limit > 100) {
+      let msg = 'Limit needs to be 100 or under';
+      throw flaverr({ name: 'UsageError', code:'E_INVALID_LIMIT', details:msg }, new Error(msg));
+    }
   }
 
   return queryOptions;


### PR DESCRIPTION
[PR](https://github.com/balderdashy/sails/pull/6967) adds 'UsageError' handling for custom `parseBlueprintOptions()` errors. This is an example usage.