### PR TITLE
[misc] Updated Locales.md typo found

### DIFF
--- a/concepts/Internationalization/Locales.md
+++ b/concepts/Internationalization/Locales.md
@@ -14,7 +14,7 @@ Here is an example locale file (`config/locales/es.json`):
 }
 ```
 
-Locales can be accessed in controller actions and policies through `res.i18n()`, or in views through the `__(key)` or `i18n(key)` functions.
+Locales can be accessed in controller actions and policies through `req.i18n()`, or in views through the `__(key)` or `i18n(key)` functions.
 
 ```ejs
 <h1> <%= __('Welcome to PencilPals!') %> </h1>


### PR DESCRIPTION
Fixed the typo. After testing, I figured that 'req.i18n' is the one that works instead of 'res'.