### PR TITLE
[patch] Update Blueprint Actions.md

### DIFF
--- a/concepts/Blueprints/Blueprint Actions.md
+++ b/concepts/Blueprints/Blueprint Actions.md
@@ -72,6 +72,6 @@ module.exports = {
 }
 ```
 
-> Alternatively, we could have created this as a standalone action at `api/controllers/user/find-one.js` or used [actions2](https://sailsjs.com/documentation/concepts/actions-and-controllers#?actions-2).
+> Alternatively, we could have created this as a standalone action at `api/controllers/user/findone.js` or used [actions2](https://sailsjs.com/documentation/concepts/actions-and-controllers#?actions-2).
 
 <docmeta name="displayName" value="Blueprint actions">


### PR DESCRIPTION
**Node version**: 12.16.3
**Sails version** _(sails)_: 1.2.4
**ORM hook version** _(sails-hook-orm)_: 2.1.1
**Sockets hook version** _(sails-hook-sockets)_: 2.0.0
**Organics hook version** _(sails-hook-organics)_: 
**Grunt hook version** _(sails-hook-grunt)_: 
**Uploads hook version** _(sails-hook-uploads)_: 
**DB adapter & version** _(e.g. sails-mysql@5.55.5)_: 
**Skipper adapter & version** _(e.g. skipper-s3@5.55.5)_: 
<hr/>

I was unable to override the Blueprint findOne action as suggested here https://sailsjs.com/documentation/concepts/blueprints/blueprint-actions#?overriding-blueprint-actions

`/api/controllers/requests/find.js` works correctly in overriding the default but my file created at `/api/controllers/requests/find-one.js` did not. I've tried naming it to "findone.js" and it worked however.