### PR TITLE
Add updated guides links

### DIFF
--- a/tutorials/full-stack-javascript.md
+++ b/tutorials/full-stack-javascript.md
@@ -8,4 +8,7 @@ This video tutorial is an in-depth guide to building your first Node.js/Sails.js
 + [Try out the demo app (Ration)](https://ration.io)
 + [Download the source code](https://github.com/mikermcneil/ration) for the demo app
 
+#### Updated Guides
++ [Sails Guide](https://www.sailsguide.com) 
+
 <docmeta name="displayName" value="Full-stack JavaScript with Sails">


### PR DESCRIPTION
It's very hard to find sites out there that have updated info on Sails 1.x - that tutorails on ration is really the only thing thats easy to find. I thought to add a links section to updated websites.