### PR TITLE
[patch] Add example to generate model cli docs

### DIFF
--- a/reference/cli/sailsgenerate.md
+++ b/reference/cli/sailsgenerate.md
@@ -15,7 +15,7 @@ The following _core generators_ are bundled with Sails:
 |  Command                        | Details               |
 |:--------------------------------|:----------------------|
 | sails generate page             | Generate four pages: .ejs, .less, page script, and view action. You must add your .less file to the importer and you must set your route for your new page to work. **Note**: `sails generate page` is intended for use with projects generated with the "Web app" template. You can still use this command if you're not using the web app template, but you'll need to delete the `assets/js/pages/page-name.page.js` file that's been generated, as it relies on dependencies that don't come bundled with an "Empty" Sails app.
-| sails generate model            | Generate **api/models/Foo.js**, including attributes with the specified types if provided.
+| sails generate model            | Generate **api/models/Foo.js**, including attributes with the specified types if provided.<br /> For example, `sails generate model User username isAdmin:boolean` will generate a User model with a `username` string attribute and an `isAdmin` boolean attribute.
 | sails generate action           | Generate a standalone [action](https://sailsjs.com/documentation/concepts/actions-and-controllers/generating-actions-and-controllers#?generating-standalone-actions).
 | sails generate helper           | Generate a [helper](https://sailsjs.com/documentation/concepts/helpers) at **api/helpers/foo.js**.
 | sails generate controller       | Generate **api/controllers/FooController.js**, including actions with the specified names if provided.


### PR DESCRIPTION
It was not clear how `generate model` takes attributes arguments and it took me a while to find out how to do it. Hopefully this helps other users.